### PR TITLE
Make parser reusable

### DIFF
--- a/bin/nearleyc.js
+++ b/bin/nearleyc.js
@@ -63,7 +63,7 @@ function Compile(structure) {
 			} else {
                 throw new Error("Should never get here");
             }
-		})
+		});
 
 		tokenList = "[" + tokenList.join(", ") + "]";
 		var out = "rules.push(nearley.rule(" + JSON.stringify(name) + ", " + tokenList +


### PR DESCRIPTION
Expose each parser as a subclass of `nearley.Parser` rather than an instance, so there's no cruft left over from one run in the next.
