### PR TITLE
Fix offsets of incremental parses

### DIFF
--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -136,20 +136,20 @@ function Parser(rules, start) {
 }
 
 Parser.prototype.feed = function(chunk) {
-    for (; this.current < chunk.length; this.current++) {
+    for (var chunkPos = 0; chunkPos < chunk.length; chunkPos++) {
         // We add new states to table[current+1]
         this.table.push([]);
 
         // Advance all tokens that expect the symbol
         // So for each state in the previous row,
 
-        for (var w = 0; w < this.table[this.current].length; w++) {
-            var s = this.table[this.current][w];
+        for (var w = 0; w < this.table[this.current + chunkPos].length; w++) {
+            var s = this.table[this.current + chunkPos][w];
             // Try to consume the token
-            var x = s.consume(chunk[this.current]);
+            var x = s.consume(chunk[chunkPos]);
             if (x) {
                 // And then add it
-                this.table[this.current+1].push(x);
+                this.table[this.current + chunkPos + 1].push(x);
             }
         }
 
@@ -161,8 +161,10 @@ Parser.prototype.feed = function(chunk) {
         // To prevent duplication, we also keep track
         // of rules we have already added
         var addedRules = [];
-        advanceTo(this.current+1, this.table, this.rules, addedRules);
+        advanceTo(this.current + chunkPos + 1, this.table, this.rules, addedRules);
     }
+
+    this.current += chunkPos;
     // Incrementally keep track of results
     this.results = this.finish();
 


### PR DESCRIPTION
Incremental parses were broken with the `feed()` API, because only the first chunk's offsets were used properly.
