### PR TITLE
Clearly delineate some of the parts of the compiler

### DIFF
--- a/bin/nearleyc.js
+++ b/bin/nearleyc.js
@@ -4,6 +4,8 @@ var fs = require('fs');
 var nearley = require('../lib/nearley.js');
 var inlineRequire = require('../lib/inline-require.js');
 var nomnom = require('nomnom');
+var Compile = require('../lib/compile.js');
+var StreamWrapper = require('../lib/stream.js');
 
 var opts = nomnom
 	.script('nearleyc')
@@ -30,89 +32,15 @@ var opts = nomnom
 	})
 	.parse();
 
-function Compile(structure) {
-	var un = 0;
-	function unique() {
-		return "  id" + (++un);
-	}
-
-	var outputRules = [];
-
-	function stringifyProductionRule(name, rule) {
-		var tokenList = [];
-
-		rule.tokens.forEach(function(token) {
-			if (token.type && token.type === 'literal') {
-				var str = token.data;
-				if (str.length > 1) {
-					var rules = str.split("").map(function(d) {
-						return {type: 'literal', 'data':d};
-					});
-					var postprocessor = "function(d) {return d.join('');}";
-
-					var newname = unique();
-					stringifyProductionRule(newname, {tokens: rules, postprocessor: postprocessor});
-					tokenList.push(JSON.stringify(newname));
-				} else if (str.length === 1) {
-					tokenList.push(JSON.stringify({ literal: str}));
-				}
-			} else if (typeof(token) === 'string') {
-				if (token !== 'null') tokenList.push(JSON.stringify(token));
-            } else if (token instanceof RegExp) {
-                tokenList.push(token.toString());
-			} else {
-                throw new Error("Should never get here");
-            }
-		})
-
-		tokenList = "[" + tokenList.join(", ") + "]";
-		var out = "rules.push(nearley.rule(" + JSON.stringify(name) + ", " + tokenList +
-			(rule.postprocessor ? ", " + rule.postprocessor : "") + "));";
-
-		outputRules.push(out);
-	}
-
-	structure.forEach(function(productionRule) {
-		var rules = productionRule.rules;
-
-		rules.forEach(function(rule) {
-			stringifyProductionRule(productionRule.name, rule);
-		});
-	});
-
-
-	var output = "";
-	var ws = "\n    ";
-
-	output += "// Generated automatically by nearley.\n";
-	output += opts.export + " = function() {";
-
-	output += ws + "var nearley = " + inlineRequire(require, '../lib/nearley.js');
-	output += ws + "var rules = [];";
-	output += ws + "var id = function(a){return a[0];};";
-	output += ws;
-	output += ws + outputRules.join("\n    ");
-	output += ws;
-	output += ws + "return new nearley.Parser(rules, " + JSON.stringify(structure[0].name) + ");";
-
-	output += "\n};";
-
-	return output;
-}
-
 var input = opts.file ? fs.createReadStream(opts.file) : process.stdin;
+var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
+
 var language = require('../lib/nearley-language.js');
 var parser = new nearley.Parser(language.rules, language.start);
 
 input
-	.on('data', function(d) {
-		parser.feed(d.toString());
-	})
-	.on('end', function() {
-		var c = Compile(parser.results[0]);
-		if (!opts.out) {
-	        process.stdout.write(c);
-	    } else {
-	        fs.writeFile(opts.out, c);
-	    }
+    .pipe(new StreamWrapper(parser))
+	.on('finish', function() {
+		var c = Compile(parser.results[0], opts);
+        output.write(c);
 	});

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,0 +1,73 @@
+var inlineRequire = require('../lib/inline-require.js');
+
+function Compile(structure, opts) {
+	var un = 0;
+	function unique() {
+		return "  id" + (++un);
+	}
+
+	var outputRules = [];
+
+	function stringifyProductionRule(name, rule) {
+		var tokenList = [];
+
+		rule.tokens.forEach(function(token) {
+			if (token.type && token.type === 'literal') {
+				var str = token.data;
+				if (str.length > 1) {
+					var rules = str.split("").map(function(d) {
+						return {type: 'literal', 'data':d};
+					});
+					var postprocessor = "function(d) {return d.join('');}";
+
+					var newname = unique();
+					stringifyProductionRule(newname, {tokens: rules, postprocessor: postprocessor});
+					tokenList.push(JSON.stringify(newname));
+				} else if (str.length === 1) {
+					tokenList.push(JSON.stringify({ literal: str}));
+				}
+			} else if (typeof(token) === 'string') {
+				if (token !== 'null') tokenList.push(JSON.stringify(token));
+            } else if (token instanceof RegExp) {
+                tokenList.push(token.toString());
+			} else {
+                throw new Error("Should never get here");
+            }
+		});
+
+		tokenList = "[" + tokenList.join(", ") + "]";
+		var out = "rules.push(nearley.rule(" + JSON.stringify(name) + ", " + tokenList +
+			(rule.postprocessor ? ", " + rule.postprocessor : "") + "));";
+
+		outputRules.push(out);
+	}
+
+	structure.forEach(function(productionRule) {
+		var rules = productionRule.rules;
+
+		rules.forEach(function(rule) {
+			stringifyProductionRule(productionRule.name, rule);
+		});
+	});
+
+
+	var output = "";
+	var ws = "\n    ";
+
+	output += "// Generated automatically by nearley.\n";
+	output += opts.export + " = function() {";
+
+	output += ws + "var nearley = " + inlineRequire(require, '../lib/nearley.js');
+	output += ws + "var rules = [];";
+	output += ws + "var id = function(a){return a[0];};";
+	output += ws;
+	output += ws + outputRules.join("\n    ");
+	output += ws;
+	output += ws + "return new nearley.Parser(rules, " + JSON.stringify(structure[0].name) + ");";
+
+	output += "\n};";
+
+	return output;
+}
+
+module.exports = Compile;

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,0 +1,16 @@
+var Writable = require('stream').Writable;
+var util = require('util');
+
+function StreamWrapper(parser) {
+    Writable.call(this);
+    this._parser = parser;
+}
+
+util.inherits(StreamWrapper, Writable);
+
+StreamWrapper.prototype._write = function write(chunk, encoding, callback) {
+    this._parser.feed(chunk.toString());
+    callback();
+};
+
+module.exports = StreamWrapper;


### PR DESCRIPTION
- Adds a stream interface wrapper to simplify interfacing with node.js
  inputs
- Extract the compiler function from the mechanics of interfacing with
  the commandline.

This should facilitate work to analyze grammars somewhat, and should make it easier to refactor the compiler into the language definition itself where appropriate.
