### PR TITLE
postprocess can now return Parser.fail

### DIFF
--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -66,20 +66,22 @@ State.prototype.process = function(location, table, rules, addedRules) {
     if (this.expect === this.rule.symbols.length) {
         // I have completed a rule
         if (this.rule.postprocess) {
-            this.data = this.rule.postprocess(this.data, this.reference);
+            this.data = this.rule.postprocess(this.data, this.reference, Parser.fail);
         }
-        var w = 0;
-        // We need a while here because the empty rule will
-        // modify table[reference]. (when location === reference)
-        var s,x;
-        while (w < table[this.reference].length) {
-            s = table[this.reference][w];
-            x = s.consumeNonTerminal(this.rule.name);
-            if (x) {
-                x.data[x.data.length-1] = this.data;
-                table[location].push(x);
+        if (!(this.data === Parser.fail)) {
+            var w = 0;
+            // We need a while here because the empty rule will
+            // modify table[reference]. (when location === reference)
+            var s,x;
+            while (w < table[this.reference].length) {
+                s = table[this.reference][w];
+                x = s.consumeNonTerminal(this.rule.name);
+                if (x) {
+                    x.data[x.data.length-1] = this.data;
+                    table[location].push(x);
+                }
+                w++;
             }
-            w++;
         }
     } else {
         // I'm not done, but I can predict something
@@ -144,6 +146,9 @@ function Parser(rules, start) {
     this.advanceTo(0, addedRules);
     this.current = 0;
 }
+
+// create a reserved token for indicating a parse fail
+Parser.fail = {};
 
 Parser.prototype.advanceTo = function(n, addedRules) {
     // Advance a table, take the closure of .process for location n in the input stream


### PR DESCRIPTION
when a rule completes, the post processor may now provide a semantic pass/fail to provide the last word on if the completed rule was a successful parse
