### PR TITLE
Potential TypeScript naming collisions

### DIFF
--- a/docs/md/parser.md
+++ b/docs/md/parser.md
@@ -149,6 +149,15 @@ file. This can be useful to write your postprocessors in a different language,
 and to get type annotations if you wish to use nearley in a statically typed
 dialect of JavaScript.
 
+#### Typescript Preprocessor Changes
+
+If you have recently upgraded to a newer version of nearly, you might have run
+into an issue with `error TS2345` talking about a variable
+`missing the following properties from type 'CompiledRules': ParserStart, ParserRules`
+This is a result of a change in the output format of the grammar, but is very easily fixed.
+Just change the way you import the grammar from `import * as grammar from "./path/to/grammar"`
+to `import grammar from "./path/to/grammar"` and everything should compile nicely again.
+
 ### What's next?
 
 Now that you know how to use parsers, [learn how to add a tokenizer to speed

--- a/docs/parser.html
+++ b/docs/parser.html
@@ -376,6 +376,13 @@ instead choose to compile to CoffeeScript or TypeScript by adding
 file. This can be useful to write your postprocessors in a different language,
 and to get type annotations if you wish to use nearley in a statically typed
 dialect of JavaScript.</p>
+<h4 id="typescript-preprocessor-changes">Typescript Preprocessor Changes</h4>
+<p>If you have recently upgraded to a newer version of nearly, you might have run
+into an issue with <code>error TS2345</code> talking about a variable
+<code>missing the following properties from type &#39;CompiledRules&#39;: ParserStart, ParserRules</code>
+This is a result of a change in the output format of the grammar, but is very easily fixed.
+Just change the way you import the grammar from <code>import * as grammar from &quot;./path/to/grammar&quot;</code>
+to <code>import grammar from &quot;./path/to/grammar&quot;</code> and everything should compile nicely again.</p>
 <h3 id="what-s-next-">What’s next?</h3>
 <p>Now that you know how to use parsers, <a href="tokenizers">learn how to add a tokenizer to speed
 things up!</a></p>

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -6,10 +6,14 @@
     }
 }(this, function(nearley) {
 
-    function serializeRules(rules, builtinPostprocessors) {
-        return "[\n    " + rules.map(function(rule) {
-          return serializeRule(rule, builtinPostprocessors);
-        }).join(",\n    ") + "\n]";
+    function serializeRules(rules, builtinPostprocessors, extraIndent) {
+        if (extraIndent == null) {
+            extraIndent = ''
+        }
+    
+        return '[\n    ' + rules.map(function(rule) {
+            return serializeRule(rule, builtinPostprocessors);
+        }).join(',\n    ') + '\n' + extraIndent + ']';
     }
 
     function dedentFunc(func) {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -10,7 +10,7 @@
         if (extraIndent == null) {
             extraIndent = ''
         }
-    
+
         return '[\n    ' + rules.map(function(rule) {
             return serializeRule(rule, builtinPostprocessors);
         }).join(',\n    ') + '\n' + extraIndent + ']';
@@ -131,6 +131,7 @@
         output += "})();\n";
         return output;
     };
+
     generate.javascript.builtinPostprocessors = {
         "joiner": "function joiner(d) {return d.join('');}",
         "arrconcat": "function arrconcat(d) {return [d[0]].concat(d[1]);}",
@@ -174,6 +175,7 @@
         output += "    window." + exportName + " = grammar;\n";
         return output;
     };
+
     generate.coffeescript.builtinPostprocessors = {
         "joiner": "(d) -> d.join('')",
         "arrconcat": "(d) -> [d[0]].concat(d[1])",
@@ -191,31 +193,44 @@
         output += parser.customTokens.map(function (token) { return "declare var " + token + ": any;\n" }).join("")
         output += parser.body.join('\n');
         output += "\n";
-        output += "export interface Token { value: any; [key: string]: any };\n";
-        output += "\n";
-        output += "export interface Lexer {\n";
-        output += "  reset: (chunk: string, info: any) => void;\n";
-        output += "  next: () => Token | undefined;\n";
-        output += "  save: () => any;\n";
-        output += "  formatError: (token: Token) => string;\n";
-        output += "  has: (tokenType: string) => boolean\n";
-        output += "};\n"
-        output += "\n";
-        output += "export interface NearleyRule {\n";
-        output += "  name: string;\n";
-        output += "  symbols: NearleySymbol[];\n";
-        output += "  postprocess?: (d: any[], loc?: number, reject?: {}) => any\n";
+        output += "interface NearleyToken {";
+        output += "  value: any;\n";
+        output += "  [key: string]: any;\n";
         output += "};\n";
         output += "\n";
-        output += "export type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean };\n";
+        output += "interface NearleyLexer {\n";
+        output += "  reset: (chunk: string, info: any) => void;\n";
+        output += "  next: () => NearleyToken | undefined;\n";
+        output += "  save: () => any;\n";
+        output += "  formatError: (token: NearleyToken) => string;\n";
+        output += "  has: (tokenType: string) => boolean;\n";
+        output += "};\n";
         output += "\n";
-        output += "export var Lexer: Lexer | undefined = " + parser.config.lexer + ";\n";
+        output += "interface NearleyRule {\n";
+        output += "  name: string;\n";
+        output += "  symbols: NearleySymbol[];\n";
+        output += "  postprocess?: (d: any[], loc?: number, reject?: {}) => any;\n";
+        output += "};\n";
         output += "\n";
-        output += "export var ParserRules: NearleyRule[] = " + serializeRules(parser.rules, generate.typescript.builtinPostprocessors) + ";\n";
+        output += "type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean };\n";
         output += "\n";
-        output += "export var ParserStart: string = " + JSON.stringify(parser.start) + ";\n";
+        output += "interface Grammar {\n";
+        output += "  Lexer: NearleyLexer | undefined;\n";
+        output += "  ParserRules: NearleyRule[];\n";
+        output += "  ParserStart: string;\n";
+        output += "};\n";
+        output += "\n";
+        output += "const grammar: Grammar = {\n";
+        output += "  Lexer: " + parser.config.lexer + ",\n";
+        output += "  ParserRules: " + serializeRules(parser.rules, generate.typescript.builtinPostprocessors, "  ") + ",\n";
+        output += "  ParserStart: " + JSON.stringify(parser.start) + ",\n";
+        output += "};\n";
+        output += "\n";
+        output += "export default grammar;\n";
+
         return output;
     };
+
     generate.typescript.builtinPostprocessors = {
         "joiner": "(d) => d.join('')",
         "arrconcat": "(d) => [d[0]].concat(d[1])",
@@ -223,7 +238,6 @@
         "nuller": "() => null",
         "id": "id"
     };
-
 
     return generate;
 

--- a/test/nearleyc.test.js
+++ b/test/nearleyc.test.js
@@ -65,7 +65,7 @@ describe("bin/nearleyc", function() {
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         sh(`tsc ${outPath}.ts`);
-        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
+        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`).default);
         expect(parse(grammar, "<123>")).toEqual([ [ '<', '123', '>' ] ]);
     });
 


### PR DESCRIPTION
### The Problem
This PR aims to remove common naming collisions from the TypeScript code generation for the following reason:

With the current implementation, code like this fails in a weird way:

```
@preprocessor typescript
@{%
import { Lexer } from '../lexer'
const lexer = new Lexer()
%}

@lexer lexer
```

Typescript will  tell us 2 warnings:
1) `TS2440: Import declaration conflicts with local declaration of 'Lexer'.`
2) `TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.`

This is because this code translates to Typescript that lives in the same scope as the boilerplate generation nearley does at the end of the file, which currently contains `export Lexer: Lexer | undefined = ...` - which is hard to understand unless you inspect the entire `grammar.ts` output file in detail.

So Typescript attempts to compile anyway and ignores our import and assumes that `Lexer` is meant to be the last definition, which lives on `exports` and is the assignment of the instance we attempted to create in the first place. To remedy this, I have done this PR.

### The Solution

This PR changes the Typescript Code Generation in 2 significant ways:

- it renames 2 interfaces
- it changes the exports to a single `grammar` object, instead of 3 individual exports
  - this has 2 effects:
  - a) align with JS & CS who already export such an object
  - b) make it nicer to use the API

Example for b) new: `import { grammar } from './grammar'` vs old: `import * as grammar from './grammar'`

## Important Notes
- This PR breaks backwards compatibility for typescript users, but the needed change is minimal as shown above
- The PR adds another optional argument to `serializeRules` to make the code generation output look nicer
