### PR TITLE
A link to the builtin directory on github in the grammar docs

### DIFF
--- a/docs/md/grammar.md
+++ b/docs/md/grammar.md
@@ -261,7 +261,7 @@ quickly. The builtins are _inefficient_ in the sense that they make your parser
 slower. For a "real" project, you would want to switch to a lexer and implement
 these primitives yourself!)
 
-See the `builtin/` directory on Github for more details. Contributions are
+See the [`builtin/`](https://github.com/kach/nearley/tree/master/builtin) directory on Github for more details. Contributions are
 welcome!
 
 Note that including a file imports *all* of the nonterminals defined in it, as


### PR DESCRIPTION
In the `@builtin` section, it says to look at the builtin/ directory on github, but it doesn't provide a link.