### PR TITLE
Fix #346: randexp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "nomnom": "~1.6.2",
     "railroad-diagrams": "^1.0.0",
-    "randexp": "^0.4.2",
+    "randexp": "0.4.6",
     "semver": "^5.4.1"
   },
   "files": [


### PR DESCRIPTION
This PR updates the `randexp` dependency to use the fixed version `0.4.6`, since the latest `0.4.7` has a [breaking change for git-less environments](https://github.com/fent/randexp.js/issues/46) when installing the package.

Issue: https://github.com/kach/nearley/issues/346