### PR TITLE
Remove TypeScript warning

### DIFF
--- a/lib/lint.js
+++ b/lib/lint.js
@@ -21,19 +21,9 @@ function lintNames(grm, opts) {
     });
 }
 
-function lintTSVersion(grm, opts) {
-    if (grm.config.preprocessor === 'typescript' &&
-        semver.gt(opts.version, '2.11.0'))
-        warn(opts, "The interface for the TypeScript preprocessor changed " +
-                   "briefly in nearley 2.10 and 2.11. See " +
-                   "https://github.com/Hardmath123/nearley/pull/287 if you " +
-                   "encounter issues importing your grammar into TS.");
-}
-
 function lint(grm, opts) {
     if (!opts.out) opts.out = process.stderr;
     lintNames(grm, opts);
-    lintTSVersion(grm, opts);
 }
 
 module.exports = lint;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nearley",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Simple, fast, powerful parser toolkit for JavaScript.",
   "main": "lib/nearley.js",
   "dependencies": {


### PR DESCRIPTION
@kach You added a lint warning in c82a2b9 to direct TypeScript users to #287.

This broke the unit tests:
```
  1) bin/nearleyc builds for TypeScript:
     Error: Expected 'WARN\tThe interface for the TypeScript preprocessor changed briefly in nearley 2.10 and 2.11. See https://github.com/Hardmath123/nearley/pull/287 if you encounter issues importing your grammar into TS.\n' to be ''
      at assert (node_modules/expect/lib/assert.js:29:9)
      at Expectation.toBe (node_modules/expect/lib/Expectation.js:66:28)
      at Context.<anonymous> (test/nearleyc.test.js:65:24)
```

We either need to amend the unit test, or remove the lint warning. Since some time has passed since the warning as added, this PR removes it.

---

*Aside:* I thought we'd enabled Travis CI, which would warn us about this sort of thing; but [it looks like](https://travis-ci.org/kach/nearley) we didn't. @kach Only you as an admin can enable it; if you wouldn't mind taking 30s to do so, that'd be grand; then I'll merge #309, to turn it on. 😃 