### PR TITLE
Token value fix

### DIFF
--- a/docs/md/tokenizers.md
+++ b/docs/md/tokenizers.md
@@ -37,7 +37,7 @@ When using a lexer, there are two ways to match tokens:
     line -> words %newline
     ```
 
-  - Use `"foo"` to match a token with **value** `foo`.
+  - Use `"foo"` to match a token with **text** `foo`.
 
     This is convenient for matching keywords:
 

--- a/docs/tokenizers.html
+++ b/docs/tokenizers.html
@@ -302,7 +302,7 @@ super-fast lexer. Construct a lexer using <code>moo.compile</code>.</p>
 <pre><code class="lang-ne">line -&gt; words %newline
 </code></pre>
 </li>
-<li><p>Use <code>&quot;foo&quot;</code> to match a token with <strong>value</strong> <code>foo</code>.</p>
+<li><p>Use <code>&quot;foo&quot;</code> to match a token with <strong>text</strong> <code>foo</code>.</p>
 <p>This is convenient for matching keywords:</p>
 <pre><code class="lang-ne">ifStatement -&gt; &quot;if&quot; condition &quot;then&quot; block
 </code></pre>

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -281,7 +281,7 @@
             this.table.push(nextColumn);
 
             // Advance all tokens that expect the symbol
-            var literal = token.value;
+            var literal = token.text !== undefined ? token.text : token.value;
             var value = lexer.constructor === StreamLexer ? token.value : token;
             var scannable = column.scannable;
             for (var w = scannable.length; w--; ) {

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -108,6 +108,24 @@ describe('bootstrapped lexer', () => {
       expect(lexTypes('"foo" "bar"')).toEqual(["string", "ws", "string"])
     })
 
+    it('lexes a rule', () => {
+        expect(lex('Tp4 -> "(" _ Tp _ ")"')).toEqual([
+          "word Tp4",
+          "ws  ",
+          "arrow ->",
+          "ws  ",
+          "string (",
+          "ws  ",
+          "word _",
+          "ws  ",
+          "word Tp",
+          "ws  ",
+          "word _",
+          "ws  ",
+          "string )",
+        ])
+    })
+
 })
 
 describe('bootstrapped parser', () => {
@@ -168,6 +186,18 @@ describe('bootstrapped parser', () => {
         check('Y -> foo["string"]')
         check('Y -> foo[%tok]')
         check('Y -> foo[(baz quxx)]')
+    })
+
+    it('parses macro use', () => {
+        check('Y -> foo[Q]')
+        check('Y -> foo[Q, P]')
+        check('Y -> foo["string"]')
+        check('Y -> foo[%tok]')
+        check('Y -> foo[(baz quxx)]')
+    })
+
+    it('parses a rule', () => {
+        check('Tp4 -> "(" _ Tp _ ")"')
     })
 
 })


### PR DESCRIPTION
Moo recently introduced a distinction between `text` (the original match) and `value`. However, Nearley literals are still matched against `value`. Moo can extract a part of a token into the `value`. (We used to do this with capture groups; now we do this with a `value` function.) For example, the value of a string token excludes the quotes.

There is a really nasty gotcha that's been bugging me for a while: if you have a literal in your grammar to match (, it will *also* match the string "("!

My proposed fix is to modify Nearley to match literals instead against `tok.text`, if present. Since this is a bugfix, and backwards compatible (we fall back to `tok.value`), this won't violate semver. :)

Related: #359 and some others