### PR TITLE
Disallow custom matchers when using a lexer

### DIFF
--- a/docs/md/tokenizers.md
+++ b/docs/md/tokenizers.md
@@ -90,8 +90,6 @@ However, you can use any lexer that conforms to the following interface:
 - `formatError(token)` returns a string with an error message describing a
   parse error at that token (for example, the string might contain the line and
   column where the error was found).
-- `has(name)` returns true if the lexer can emit tokens with that name. This is
-  used to resolve `%`-specifiers in compiled nearley grammars.
 
 > Note: if you are searching for a lexer that allows indentation-aware
 > grammars (like in Python), you can still use moo. See [this
@@ -120,3 +118,7 @@ main -> %tokenPrint %tokenNumber ";;"
 
 # parser.feed(["print", 12, ";;"]);
 ```
+
+Note that this is only supported if you *don't* use `@lexer`. When using
+Nearley with Moo, `%foo` instead matches a *token of type `foo`*. Any JS
+variables named `foo` defined in your grammar have no effect.

--- a/docs/tokenizers.html
+++ b/docs/tokenizers.html
@@ -346,8 +346,6 @@ restores its state to a state returned by <code>save()</code>.</li>
 <li><code>formatError(token)</code> returns a string with an error message describing a
 parse error at that token (for example, the string might contain the line and
 column where the error was found).</li>
-<li><code>has(name)</code> returns true if the lexer can emit tokens with that name. This is
-used to resolve <code>%</code>-specifiers in compiled nearley grammars.</li>
 </ul>
 <blockquote>
 <p>Note: if you are searching for a lexer that allows indentation-aware
@@ -371,6 +369,9 @@ main -&gt; %tokenPrint %tokenNumber &quot;;;&quot;
 
 # parser.feed([&quot;print&quot;, 12, &quot;;;&quot;]);
 </code></pre>
+<p>Note that this is only supported if you <em>don’t</em> use <code>@lexer</code>. When using
+Nearley with Moo, <code>%foo</code> instead matches a <em>token of type <code>foo</code></em>. Any JS
+variables named <code>foo</code> defined in your grammar have no effect.</p>
 
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -131,8 +131,7 @@
                     if (result.customTokens.indexOf(name) === -1) {
                         result.customTokens.push(name);
                     }
-                    var expr = result.config.lexer + ".has(" + JSON.stringify(name) + ") ? {type: " + JSON.stringify(name) + "} : " + name;
-                    return {token: "(" + expr + ")"};
+                    return {token: "{type: " + JSON.stringify(name) + "}"};
                 }
                 return token;
             }

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -194,7 +194,6 @@
         output += "  next: () => Token | undefined;\n";
         output += "  save: () => any;\n";
         output += "  formatError: (token: Token) => string;\n";
-        output += "  has: (tokenType: string) => boolean\n";
         output += "};\n"
         output += "\n";
         output += "export interface NearleyRule {\n";

--- a/lib/nearley-language-bootstrapped.js
+++ b/lib/nearley-language-bootstrapped.js
@@ -101,8 +101,8 @@ var grammar = {
     {"name": "final", "symbols": ["_", "prog", "_"], "postprocess": function(d) { return d[1]; }},
     {"name": "prog", "symbols": ["prod"], "postprocess": function(d) { return [d[0]]; }},
     {"name": "prog", "symbols": ["prod", "ws", "prog"], "postprocess": function(d) { return [d[0]].concat(d[2]); }},
-    {"name": "prod", "symbols": ["word", "_", (lexer.has("arrow") ? {type: "arrow"} : arrow), "_", "expression+"], "postprocess": function(d) { return {name: d[0], rules: d[4]}; }},
-    {"name": "prod", "symbols": ["word", {"literal":"["}, "wordlist", {"literal":"]"}, "_", (lexer.has("arrow") ? {type: "arrow"} : arrow), "_", "expression+"], "postprocess": function(d) {return {macro: d[0], args: d[2], exprs: d[7]}}},
+    {"name": "prod", "symbols": ["word", "_", {type: "arrow"}, "_", "expression+"], "postprocess": function(d) { return {name: d[0], rules: d[4]}; }},
+    {"name": "prod", "symbols": ["word", {"literal":"["}, "wordlist", {"literal":"]"}, "_", {type: "arrow"}, "_", "expression+"], "postprocess": function(d) {return {macro: d[0], args: d[2], exprs: d[7]}}},
     {"name": "prod", "symbols": [{"literal":"@"}, "_", "js"], "postprocess": function(d) { return {body: d[2]}; }},
     {"name": "prod", "symbols": [{"literal":"@"}, "word", "ws", "word"], "postprocess": function(d) { return {config: d[1], value: d[3]}; }},
     {"name": "prod", "symbols": [{"literal":"@include"}, "_", "string"], "postprocess": function(d) {return {include: d[2].literal, builtin: false}}},
@@ -130,18 +130,18 @@ var grammar = {
     {"name": "ebnf_modifier", "symbols": [{"literal":":?"}], "postprocess": getValue},
     {"name": "expr", "symbols": ["expr_member"]},
     {"name": "expr", "symbols": ["expr", "ws", "expr_member"], "postprocess": function(d){ return d[0].concat([d[2]]); }},
-    {"name": "word", "symbols": [(lexer.has("word") ? {type: "word"} : word)], "postprocess": getValue},
-    {"name": "string", "symbols": [(lexer.has("string") ? {type: "string"} : string)], "postprocess": d => ({literal: d[0].value})},
-    {"name": "string", "symbols": [(lexer.has("btstring") ? {type: "btstring"} : btstring)], "postprocess": d => ({literal: d[0].value})},
-    {"name": "charclass", "symbols": [(lexer.has("charclass") ? {type: "charclass"} : charclass)], "postprocess": getValue},
-    {"name": "js", "symbols": [(lexer.has("js") ? {type: "js"} : js)], "postprocess": getValue},
+    {"name": "word", "symbols": [{type: "word"}], "postprocess": getValue},
+    {"name": "string", "symbols": [{type: "string"}], "postprocess": d => ({literal: d[0].value})},
+    {"name": "string", "symbols": [{type: "btstring"}], "postprocess": d => ({literal: d[0].value})},
+    {"name": "charclass", "symbols": [{type: "charclass"}], "postprocess": getValue},
+    {"name": "js", "symbols": [{type: "js"}], "postprocess": getValue},
     {"name": "_$ebnf$1", "symbols": ["ws"], "postprocess": id},
     {"name": "_$ebnf$1", "symbols": [], "postprocess": function(d) {return null;}},
     {"name": "_", "symbols": ["_$ebnf$1"]},
-    {"name": "ws", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
-    {"name": "ws$ebnf$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": id},
+    {"name": "ws", "symbols": [{type: "ws"}]},
+    {"name": "ws$ebnf$1", "symbols": [{type: "ws"}], "postprocess": id},
     {"name": "ws$ebnf$1", "symbols": [], "postprocess": function(d) {return null;}},
-    {"name": "ws", "symbols": ["ws$ebnf$1", (lexer.has("comment") ? {type: "comment"} : comment), "_"]}
+    {"name": "ws", "symbols": ["ws$ebnf$1", {type: "comment"}, "_"]}
 ]
   , ParserStart: "final"
 }


### PR DESCRIPTION
This is a small change to disallow using custom matchers—functions of the form `{test: (token: Any) -> Boolean}`—when using the `@lexer` directive.

From the updated docs:

> ```js
>  const tokenNumber = { test: x => Number.isInteger(x) };
> ```
> [snip]
>
> Note that this is only supported if you *don't* use `@lexer`. When using
> Nearley with Moo, `%foo` instead matches a *token of type `foo`*. Any JS
> variables named `foo` defined in your grammar have no effect.

I don't believe anyone is using custom matchers together with a tokenizer, and I don't think it would be a particularly useful or sensible thing to do.

Disallowing this makes the code cleaner, allows us to pay down a little bit of technical debt, and should make the parser easier to maintain going forward (_watch this space_...). (Plus, we get to delete some code from Moo!)