### PR TITLE
Syntax highlighting for docs

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <title>Getting started - nearley.js - JS Parsing Toolkit</title>
-<meta charset="utf-8"/>
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
-@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
+  @import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -145,11 +145,23 @@ code {
 
 pre code, .highlight pre {
     border-radius: 0.5em;
-    padding: 0.5em;
+    margin: 5px;
+    padding: 10px;
     display: block;
     overflow: auto;
 }
 
+.highlight pre {
+    padding: 0;
+    margin: 0;
+    display: block;
+    overflow-x: auto;
+}
+
+pre > code > pre > code {
+    padding: 0;
+    margin: 0;
+}
 
 ol {
     counter-reset: tutorial-counter;
@@ -206,7 +218,7 @@ nav ul a {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 0.25em 0.5em; */
+    padding: 0.25em 0.5em;
 }
 .page {
     display: block;
@@ -241,96 +253,141 @@ nav ul a {
     }
 }
 
-.highlight pre {
-  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+code pre {
+    margin: 0;
 }
-
 </style>
 
-<body class="docs-page">
+<body class="docs-page" >
 
-<a href="https://github.com/kach/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-<nav id="nav">
-    <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">2.12.1</span></a></h1>
+  <a href="https://github.com/kach/nearley" class="github-corner">
+    <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg>
+  </a>
+  <style>
+    .github-corner:hover .octo-arm {
+      animation: octocat-wave 560ms ease-in-out
+    }
+
+    @keyframes octocat-wave {
+      0%,
+      100% {
+        transform: rotate(0)
+      }
+      20%,
+      60% {
+        transform: rotate(-25deg)
+      }
+      40%,
+      80% {
+        transform: rotate(10deg)
+      }
+    }
+
+    @media (max-width:500px) {
+      .github-corner:hover .octo-arm {
+        animation: none
+      }
+      .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out
+      }
+    }
+  </style>
+  <nav id="nav">
+    <h1>
+      <a href="/">nearley
+        <span style="color: #559;">.js</span>
+        <span id="version">2.12.1</span>
+      </a>
+    </h1>
     <ul>
-        <li class="page"><a href="/docs/index">Home</a>
-        <li class="page">
-            <a href="#" class="page-title-active">Getting started</a>
-            <ul>
-                <li class="page-heading"><a href="#installation">
-Installation</a></li>
-                <li class="page-heading"><a href="#nearley-in-3-steps">
-nearley in 3 steps</a></li>
-                <li class="page-heading"><a href="#whats-next">
-What&#x27;s next?</a></li>
-                <li class="page-heading"><a href="#further-reading">
-Further reading</a></li>
-            </ul>
+               <li class="page">
+          <a href="/docs/index">Home</a>
+            
+      <li class="page">
+        <a href="#" class="page-title-active">Getting started</a>
+        <ul>
+          <li class="page-heading">
+            <a href="#installation">Installation</a>
+          <li class="page-heading">
+            <a href="#nearley-in-3-steps">nearley in 3 steps</a>
+          <li class="page-heading">
+            <a href="#what-s-next-">What’s next?</a>
+          <li class="page-heading">
+            <a href="#further-reading">Further reading</a>
+        </ul>
         </li>
-        <li class="page"><a href="/docs/grammar">Writing a parser</a>
-        <li class="page"><a href="/docs/parser">Using a parser</a>
-        <li class="page"><a href="/docs/tokenizers">Tokenizers</a>
-        <li class="page"><a href="/docs/tooling">Tooling</a>
-        <li class="page"><a href="/docs/how-to-grammar-good">How to grammar good</a>
-        <li class="page"><a href="/docs/using-in-frontend">Compiling in browsers</a>
-        <li class="page"><a href="/docs/glossary">Glossary</a>
+          <li class="page">
+          <a href="/docs/grammar">Writing a parser</a>
+                    <li class="page">
+          <a href="/docs/parser">Using a parser</a>
+                    <li class="page">
+          <a href="/docs/tokenizers">Tokenizers</a>
+                    <li class="page">
+          <a href="/docs/tooling">Tooling</a>
+                    <li class="page">
+          <a href="/docs/how-to-grammar-good">How to grammar good</a>
+                    <li class="page">
+          <a href="/docs/using-in-frontend">Compiling in browsers</a>
+                    <li class="page">
+          <a href="/docs/glossary">Glossary</a>
+           
     </ul>
-</nav>
+  </nav>
 
-<div id="main" class="center">
+  <div id="main" class="center">
 
-<h2>Getting started</h2>
-<html><head></head><body><p>nearley consists of two components: a <em>compiler</em> and a <em>parser</em>.</p>
+    <h2>Getting started</h2>
+    <p>nearley consists of two components: a <em>compiler</em> and a <em>parser</em>.</p>
 <p>The nearley <em>compiler</em> converts grammar definitions from a simple
-<a href="https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form" rel="nofollow">BNF</a>-based syntax to a small
+<a href="https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form">BNF</a>-based syntax to a small
 JS module. You can then use that module to construct a nearley <em>parser</em>, which
 parses input strings.</p>
-<h3 id="installation">
-Installation</h3>
+<h3 id="installation">Installation</h3>
 <p>Both components are published as a single
-<a href="https://docs.npmjs.com/getting-started/what-is-npm" rel="nofollow">NPM</a> package compatible
-with <a href="https://nodejs.org/en/" rel="nofollow">Node.js</a> and most browsers.</p>
+<a href="https://docs.npmjs.com/getting-started/what-is-npm">NPM</a> package compatible
+with <a href="https://nodejs.org/en/">Node.js</a> and most browsers.</p>
 <p>To use the nearley <em>parser</em>, you need to install nearley <strong>locally</strong>.</p>
-<div class="highlight highlight-source-shell"><pre>$ npm install --save nearley</pre></div>
+<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ npm install --save nearley</pre></div></code></pre>
 <p>To use the nearley <em>compiler</em>, you need to <em>additionally</em> install nearley
 <strong>globally</strong>.</p>
-<div class="highlight highlight-source-shell"><pre>$ npm install -g nearley</pre></div>
+<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ npm install -g nearley</pre></div></code></pre>
 <p>This actually adds several new commands to your <code>$PATH</code>:</p>
 <ul>
-<li>
-<code>nearleyc</code> compiles grammar files to JavaScript.</li>
-<li>
-<code>nearley-test</code> lets you quickly test a grammar against some input and see the
-results. It also lets you explore the internal state of nearley&apos;s Earley
+<li><code>nearleyc</code> compiles grammar files to JavaScript.</li>
+<li><code>nearley-test</code> lets you quickly test a grammar against some input and see the
+results. It also lets you explore the internal state of nearley’s Earley
 table, in case you find that interesting.</li>
-<li>
-<code>nearley-unparse</code> inverts a parser into a generator, allowing you to create
+<li><code>nearley-unparse</code> inverts a parser into a generator, allowing you to create
 random strings that match your grammar.</li>
-<li>
-<code>nearley-railroad</code> generates pretty railroad diagrams from your parser. This
+<li><code>nearley-railroad</code> generates pretty railroad diagrams from your parser. This
 is mainly helpful for creating documentation, as (for example) on json.org.</li>
 </ul>
 <p>These are documented on the <a href="tooling">tooling page</a>.</p>
 <blockquote>
-<p>Note: If you&apos;re not ready to install nearley yet, you can follow along in
-your browser using the <a href="https://omrelli.ug/nearley-playground/" rel="nofollow">nearley
+<p>Note: If you’re not ready to install nearley yet, you can follow along in
+your browser using the <a href="https://omrelli.ug/nearley-playground/">nearley
 playground</a>, an online interface for
 exploring nearley grammars interactively.</p>
 </blockquote>
-<h3 id="nearley-in-3-steps">
-nearley in 3 steps</h3>
+<h3 id="nearley-in-3-steps">nearley in 3 steps</h3>
 <p>nearley was written with users in mind: getting started with nearley is as
 simple as:</p>
 <p><strong>Step 1: Describe your grammar</strong> using the <a href="grammar">nearley syntax</a>. In
 a file called <code>grammar.ne</code>, write:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-k">(</span><span class="pl-en">statement</span> <span class="pl-s">&quot;<span class="pl-cce">\n</span>&quot;</span><span class="pl-k">):+</span>
-<span class="pl-en">statement</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;foo&quot;</span> <span class="pl-k">|</span> <span class="pl-s">&quot;bar&quot;</span></pre></div>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-k">(</span><span class="pl-en">statement</span> <span class="pl-s">&quot;<span class="pl-cce">\n</span>&quot;</span><span class="pl-k">):+</span>
+<span class="pl-en">statement</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;foo&quot;</span> <span class="pl-k">|</span> <span class="pl-s">&quot;bar&quot;</span></pre></div></code></pre>
 <p><strong>Step 2: Compile</strong> the grammar to a JavaScript module. On the command line,
 run:</p>
-<div class="highlight highlight-source-shell"><pre>$ nearleyc grammar.ne -o grammar.js</pre></div>
+<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ nearleyc grammar.ne -o grammar.js</pre></div></code></pre>
 <p><strong>Step 3: Parse</strong> some data! In a new JavaScript file, instantiate a <a href="parser">Parser
 object</a> and feed it a string:</p>
-<div class="highlight highlight-source-js"><pre><span class="pl-k">const</span> <span class="pl-c1">nearley</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley<span class="pl-pds">&quot;</span></span>);
+<pre><code class="language-js"><div class="highlight highlight-source-js"><pre><span class="pl-k">const</span> <span class="pl-c1">nearley</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley<span class="pl-pds">&quot;</span></span>);
 <span class="pl-k">const</span> <span class="pl-c1">grammar</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>./grammar.js<span class="pl-pds">&quot;</span></span>);
 
 <span class="pl-c"><span class="pl-c">//</span> Create a Parser object from our grammar.</span>
@@ -340,61 +397,64 @@ object</a> and feed it a string:</p>
 <span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>foo<span class="pl-cce">\n</span><span class="pl-pds">&quot;</span></span>);
 
 <span class="pl-c"><span class="pl-c">//</span> parser.results is an array of possible parsings.</span>
-<span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-smi">parser</span>.<span class="pl-smi">results</span>); <span class="pl-c"><span class="pl-c">//</span> [[[[ &quot;foo&quot; ],&quot;\n&quot; ]]]</span></pre></div>
-<h3 id="whats-next">
-What&apos;s next?</h3>
+<span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-smi">parser</span>.<span class="pl-smi">results</span>); <span class="pl-c"><span class="pl-c">//</span> [[[[ &quot;foo&quot; ],&quot;\n&quot; ]]]</span></pre></div></code></pre>
+<h3 id="what-s-next-">What’s next?</h3>
 <p>Now that you have nearley installed, you can <a href="grammar">learn how to write a
 grammar</a>!</p>
-<h3 id="further-reading">
-Further reading</h3>
+<h3 id="further-reading">Further reading</h3>
 <ul>
-<li>Take a look at a <a href="https://medium.com/@gajus/parsing-absolutely-anything-in-javascript-using-earley-algorithm-886edcc31e5e" rel="nofollow">nearley
+<li>Take a look at a <a href="https://medium.com/@gajus/parsing-absolutely-anything-in-javascript-using-earley-algorithm-886edcc31e5e">nearley
 tutorial</a>
 written by @gajus.</li>
-<li>Read my <a href="http://hardmath123.github.io/earley.html" rel="nofollow">blog post</a> to learn more
+<li>Read my <a href="http://hardmath123.github.io/earley.html">blog post</a> to learn more
 about the algorithm.</li>
-<li>Read about <a href="http://savage.net.au/Marpa.html" rel="nofollow">Marpa</a> to
+<li>Read about <a href="http://savage.net.au/Marpa.html">Marpa</a> to
 learn more than you ever thought you wanted to know about parsing.</li>
 </ul>
-</body></html>
-
-    <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
-    href="http://hardmath123.github.io">Hardmath123</a> (<a
-    href="http://github.com/Hardmath123">Github</a>). You're welcome to
-    leave questions, comments, advice, or ideas as Github issues. And
-    feel free to fork nearley with your own experiments!<br/>
-
-    <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
-    <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
-</div>
 
 
-<script>
-window.addEventListener("scroll", onScroll);
-window.addEventListener("resize", onScroll);
+    <div id="footer">
+      <p>nearley is MIT-licensed. It's maintained by
+        <a href="http://hardmath123.github.io">Hardmath123</a> (
+        <a href="http://github.com/Hardmath123">Github</a>). You're welcome to leave questions, comments, advice, or ideas as Github issues. And feel free to fork
+        nearley with your own experiments!
+        <br/>
 
-var timeout;
-function onScroll(e) {
-  if (timeout) clearTimeout(timeout);
-  timeout = setTimeout(scrollEnd, 50);
-}
+        <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
+          <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo" />
+        </a>
+    </div>
 
-function scrollEnd() {
-  var headings = document.querySelectorAll("h3");
-  var offset = 60;
-  for (var i = headings.length; i--; ) {
-    var h3 = headings[i];
-    if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector(".page-heading-active");
-      if (cur) cur.className = "page-heading";
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
-        "page-heading page-heading-active";
-      return;
-    }
-  }
-}
-</script>
+    <script>
+      window.addEventListener('scroll', onScroll)
+      window.addEventListener('resize', onScroll)
+      var timeout
+      function onScroll(e) {
+        if (timeout) clearTimeout(timeout)
+        timeout = setTimeout(scrollEnd, 50)
+      }
+      function scrollEnd() {
+        var headings = document.querySelectorAll('h3')
+        var offset = 60
+        for (var i = headings.length; i--;) {
+          var h3 = headings[i]
+          if (h3.offsetTop < window.scrollY + offset) {
+            var cur = document.querySelector('.page-heading-active')
+            if (cur) cur.className = 'page-heading'
+            document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
+            return
+          }
+        }
+      }
+    </script>
 
-<script>
-(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
-</script>
+    <script>
+      (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-46120535-5', 'auto');
+      ga('send', 'pageview');
+    </script>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -4,6 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
+@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -142,7 +143,7 @@ code {
     background-color: #eee;
 }
 
-pre code {
+pre code, .highlight pre {
     border-radius: 0.5em;
     padding: 0.5em;
     display: block;
@@ -242,8 +243,9 @@ nav ul a {
 
 /* highlight.js */
 
-.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
-
+.highlight pre {
+  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+}
 
 </style>
 
@@ -257,10 +259,14 @@ nav ul a {
         <li class="page">
             <a href="#" class="page-title-active">Getting started</a>
             <ul>
-                <li class="page-heading"><a href="#installation">Installation</a>
-                <li class="page-heading"><a href="#nearley-in-3-steps">nearley in 3 steps</a>
-                <li class="page-heading"><a href="#what-s-next-">What’s next?</a>
-                <li class="page-heading"><a href="#further-reading">Further reading</a>
+                <li class="page-heading"><a href="#installation">
+Installation</a></li>
+                <li class="page-heading"><a href="#nearley-in-3-steps">
+nearley in 3 steps</a></li>
+                <li class="page-heading"><a href="#whats-next">
+What&#x27;s next?</a></li>
+                <li class="page-heading"><a href="#further-reading">
+Further reading</a></li>
             </ul>
         </li>
         <li class="page"><a href="/docs/grammar">Writing a parser</a>
@@ -276,132 +282,141 @@ nav ul a {
 <div id="main" class="center">
 
 <h2>Getting started</h2>
-<p>nearley consists of two components: a <em>compiler</em> and a <em>parser</em>.</p>
+<html><head></head><body><p>nearley consists of two components: a <em>compiler</em> and a <em>parser</em>.</p>
 <p>The nearley <em>compiler</em> converts grammar definitions from a simple
-<a href="https://en.wikipedia.org/wiki/Backus–Naur_form">BNF</a>-based syntax to a small
+<a href="https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form" rel="nofollow">BNF</a>-based syntax to a small
 JS module. You can then use that module to construct a nearley <em>parser</em>, which
 parses input strings.</p>
-<h3 id="installation">Installation</h3>
+<h3 id="installation">
+Installation</h3>
 <p>Both components are published as a single
-<a href="https://docs.npmjs.com/getting-started/what-is-npm">NPM</a> package compatible
-with <a href="https://nodejs.org/en/">Node.js</a> and most browsers.</p>
+<a href="https://docs.npmjs.com/getting-started/what-is-npm" rel="nofollow">NPM</a> package compatible
+with <a href="https://nodejs.org/en/" rel="nofollow">Node.js</a> and most browsers.</p>
 <p>To use the nearley <em>parser</em>, you need to install nearley <strong>locally</strong>.</p>
-<pre><code class="lang-bash">$ npm install --save nearley
-</code></pre>
+<div class="highlight highlight-source-shell"><pre>$ npm install --save nearley</pre></div>
 <p>To use the nearley <em>compiler</em>, you need to <em>additionally</em> install nearley
 <strong>globally</strong>.</p>
-<pre><code class="lang-bash">$ npm install -g nearley
-</code></pre>
+<div class="highlight highlight-source-shell"><pre>$ npm install -g nearley</pre></div>
 <p>This actually adds several new commands to your <code>$PATH</code>:</p>
 <ul>
-<li><code>nearleyc</code> compiles grammar files to JavaScript.</li>
-<li><code>nearley-test</code> lets you quickly test a grammar against some input and see the
-results. It also lets you explore the internal state of nearley’s Earley
+<li>
+<code>nearleyc</code> compiles grammar files to JavaScript.</li>
+<li>
+<code>nearley-test</code> lets you quickly test a grammar against some input and see the
+results. It also lets you explore the internal state of nearley&apos;s Earley
 table, in case you find that interesting.</li>
-<li><code>nearley-unparse</code> inverts a parser into a generator, allowing you to create
+<li>
+<code>nearley-unparse</code> inverts a parser into a generator, allowing you to create
 random strings that match your grammar.</li>
-<li><code>nearley-railroad</code> generates pretty railroad diagrams from your parser. This
+<li>
+<code>nearley-railroad</code> generates pretty railroad diagrams from your parser. This
 is mainly helpful for creating documentation, as (for example) on json.org.</li>
 </ul>
 <p>These are documented on the <a href="tooling">tooling page</a>.</p>
 <blockquote>
-<p>Note: If you’re not ready to install nearley yet, you can follow along in
-your browser using the <a href="https://omrelli.ug/nearley-playground/">nearley
+<p>Note: If you&apos;re not ready to install nearley yet, you can follow along in
+your browser using the <a href="https://omrelli.ug/nearley-playground/" rel="nofollow">nearley
 playground</a>, an online interface for
 exploring nearley grammars interactively.</p>
 </blockquote>
-<h3 id="nearley-in-3-steps">nearley in 3 steps</h3>
+<h3 id="nearley-in-3-steps">
+nearley in 3 steps</h3>
 <p>nearley was written with users in mind: getting started with nearley is as
 simple as:</p>
 <p><strong>Step 1: Describe your grammar</strong> using the <a href="grammar">nearley syntax</a>. In
 a file called <code>grammar.ne</code>, write:</p>
-<pre><code class="lang-ne">main -&gt; (statement &quot;\n&quot;):+
-statement -&gt; &quot;foo&quot; | &quot;bar&quot;
-</code></pre>
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-k">(</span><span class="pl-en">statement</span> <span class="pl-s">&quot;<span class="pl-cce">\n</span>&quot;</span><span class="pl-k">):+</span>
+<span class="pl-en">statement</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;foo&quot;</span> <span class="pl-k">|</span> <span class="pl-s">&quot;bar&quot;</span></pre></div>
 <p><strong>Step 2: Compile</strong> the grammar to a JavaScript module. On the command line,
 run:</p>
-<pre><code class="lang-bash">$ nearleyc grammar.ne -o grammar.js
-</code></pre>
+<div class="highlight highlight-source-shell"><pre>$ nearleyc grammar.ne -o grammar.js</pre></div>
 <p><strong>Step 3: Parse</strong> some data! In a new JavaScript file, instantiate a <a href="parser">Parser
 object</a> and feed it a string:</p>
-<pre><code class="lang-js">const nearley = require(&quot;nearley&quot;);
-const grammar = require(&quot;./grammar.js&quot;);
+<div class="highlight highlight-source-js"><pre><span class="pl-k">const</span> <span class="pl-c1">nearley</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley<span class="pl-pds">&quot;</span></span>);
+<span class="pl-k">const</span> <span class="pl-c1">grammar</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>./grammar.js<span class="pl-pds">&quot;</span></span>);
 
-// Create a Parser object from our grammar.
-const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
+<span class="pl-c"><span class="pl-c">//</span> Create a Parser object from our grammar.</span>
+<span class="pl-k">const</span> <span class="pl-c1">parser</span> <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">nearley.Parser</span>(<span class="pl-smi">nearley</span>.<span class="pl-smi">Grammar</span>.<span class="pl-en">fromCompiled</span>(grammar));
 
-// Parse something!
-parser.feed(&quot;foo\n&quot;);
+<span class="pl-c"><span class="pl-c">//</span> Parse something!</span>
+<span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>foo<span class="pl-cce">\n</span><span class="pl-pds">&quot;</span></span>);
 
-// parser.results is an array of possible parsings.
-console.log(parser.results); // [[[[ &quot;foo&quot; ],&quot;\n&quot; ]]]
-</code></pre>
-<h3 id="what-s-next-">What’s next?</h3>
+<span class="pl-c"><span class="pl-c">//</span> parser.results is an array of possible parsings.</span>
+<span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-smi">parser</span>.<span class="pl-smi">results</span>); <span class="pl-c"><span class="pl-c">//</span> [[[[ &quot;foo&quot; ],&quot;\n&quot; ]]]</span></pre></div>
+<h3 id="whats-next">
+What&apos;s next?</h3>
 <p>Now that you have nearley installed, you can <a href="grammar">learn how to write a
 grammar</a>!</p>
-<h3 id="further-reading">Further reading</h3>
+<h3 id="further-reading">
+Further reading</h3>
 <ul>
-<li>Take a look at a <a href="https://medium.com/@gajus/parsing-absolutely-anything-in-javascript-using-earley-algorithm-886edcc31e5e">nearley
+<li>Take a look at a <a href="https://medium.com/@gajus/parsing-absolutely-anything-in-javascript-using-earley-algorithm-886edcc31e5e" rel="nofollow">nearley
 tutorial</a>
 written by @gajus.</li>
-<li>Read my <a href="http://hardmath123.github.io/earley.html">blog post</a> to learn more
+<li>Read my <a href="http://hardmath123.github.io/earley.html" rel="nofollow">blog post</a> to learn more
 about the algorithm.</li>
-<li>Read about <a href="http://savage.net.au/Marpa.html">Marpa</a> to
+<li>Read about <a href="http://savage.net.au/Marpa.html" rel="nofollow">Marpa</a> to
 learn more than you ever thought you wanted to know about parsing.</li>
 </ul>
-
+</body></html>
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
     href="http://hardmath123.github.io">Hardmath123</a> (<a
     href="http://github.com/Hardmath123">Github</a>). You're welcome to
     leave questions, comments, advice, or ideas as Github issues. And
     feel free to fork nearley with your own experiments!<br/>
-    
+
     <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
     <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
 </div>
 
-<script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>
-document.querySelector('#highlight-js').addEventListener('load', function() {
-    [].slice.apply(document.querySelectorAll('pre code')).forEach(function(b) {
-        hljs.highlightBlock(b)
-    })
-})
-</script>
-
 
 <script>
-window.addEventListener('scroll', onScroll)
-window.addEventListener('resize', onScroll)
+window.addEventListener("scroll", onScroll);
+window.addEventListener("resize", onScroll);
 
-var timeout
+var timeout;
 function onScroll(e) {
-    if (timeout) clearTimeout(timeout)
-    timeout = setTimeout(scrollEnd, 50)
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(scrollEnd, 50);
 }
 
 function scrollEnd() {
-  var headings = document.querySelectorAll('h3')
-  var offset = 60
-  for (var i=headings.length; i--; ) {
-    var h3 = headings[i]
+  var headings = document.querySelectorAll("h3");
+  var offset = 60;
+  for (var i = headings.length; i--; ) {
+    var h3 = headings[i];
     if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector('.page-heading-active')
-      if (cur) cur.className = 'page-heading'
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
-      return
+      var cur = document.querySelector(".page-heading-active");
+      if (cur) cur.className = "page-heading";
+      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
+        "page-heading page-heading-active";
+      return;
     }
   }
 }
 </script>
 
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-46120535-5', 'auto');
-ga('send', 'pageview');
+(function(i, s, o, g, r, a, m) {
+  i["GoogleAnalyticsObject"] = r;
+  (i[r] =
+    i[r] ||
+    function() {
+      (i[r].q = i[r].q || []).push(arguments);
+    }),
+    (i[r].l = 1 * new Date());
+  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+  a.async = 1;
+  a.src = g;
+  m.parentNode.insertBefore(a, m);
+})(
+  window,
+  document,
+  "script",
+  "https://www.google-analytics.com/analytics.js",
+  "ga"
+);
+ga("create", "UA-46120535-5", "auto");
+ga("send", "pageview");
 </script>
-

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -449,12 +449,12 @@ learn more than you ever thought you wanted to know about parsing.</li>
     </script>
 
     <script>
-      (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-      ga('create', 'UA-46120535-5', 'auto');
-      ga('send', 'pageview');
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-46120535-5', 'auto');
+ga('send', 'pageview');
     </script>
+  </div>
+</body>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -241,8 +241,6 @@ nav ul a {
     }
 }
 
-/* highlight.js */
-
 .highlight pre {
   display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
 }
@@ -398,25 +396,5 @@ function scrollEnd() {
 </script>
 
 <script>
-(function(i, s, o, g, r, a, m) {
-  i["GoogleAnalyticsObject"] = r;
-  (i[r] =
-    i[r] ||
-    function() {
-      (i[r].q = i[r].q || []).push(arguments);
-    }),
-    (i[r].l = 1 * new Date());
-  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-  a.async = 1;
-  a.src = g;
-  m.parentNode.insertBefore(a, m);
-})(
-  window,
-  document,
-  "script",
-  "https://www.google-analytics.com/analytics.js",
-  "ga"
-);
-ga("create", "UA-46120535-5", "auto");
-ga("send", "pageview");
+(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
 </script>

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -427,12 +427,12 @@ several additional utilities for building languages</p>
     </script>
 
     <script>
-      (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-      ga('create', 'UA-46120535-5', 'auto');
-      ga('send', 'pageview');
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-46120535-5', 'auto');
+ga('send', 'pageview');
     </script>
+  </div>
+</body>

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -4,6 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
+@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -142,7 +143,7 @@ code {
     background-color: #eee;
 }
 
-pre code {
+pre code, .highlight pre {
     border-radius: 0.5em;
     padding: 0.5em;
     display: block;
@@ -242,8 +243,9 @@ nav ul a {
 
 /* highlight.js */
 
-.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
-
+.highlight pre {
+  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+}
 
 </style>
 
@@ -270,9 +272,9 @@ nav ul a {
 <div id="main" class="center">
 
 <h2>Glossary</h2>
-<p>Parsing terminology gets very confusing very quickly. Here is a glossary that
+<html><head></head><body><p>Parsing terminology gets very confusing very quickly. Here is a glossary that
 can help us all communicate more effectively.</p>
-<p><strong>token</strong>: the smallest meaningful unit (the “words”) of your language</p>
+<p><strong>token</strong>: the smallest meaningful unit (the &quot;words&quot;) of your language</p>
 <p><strong>lexer</strong>: a function that converts a sequence of <em>characters</em> to a sequence of
 <em>tokens</em> (converts a sequence of letters and spaces to a sequence of words)</p>
 <p><strong>string</strong>: a sequence of <em>tokens</em></p>
@@ -293,7 +295,7 @@ that match</p>
 <p><strong>Backus-Naur Form</strong>: a set of conventions for describing and typesetting
 context-free grammars</p>
 <p><strong>recognizer</strong>: a function that takes a <em>grammar</em> and a <em>string</em> and sees if
-the grammar matches the string (it just says “yes” or “no”)</p>
+the grammar matches the string (it just says &quot;yes&quot; or &quot;no&quot;)</p>
 <p><strong>parser</strong>: a function that takes a <em>grammar</em> and a <em>string</em> and returns a
 <em>derivation</em> of that string from that grammar</p>
 <p><strong>derivation</strong>: a way to apply the production rules of a <em>grammar</em> recursively
@@ -307,10 +309,10 @@ example, you can emit TypeScript code instead of plain JavaScript (not to be
 confused with <em>postprocessor</em>)</p>
 <p><strong>postprocessor</strong>: a function associated with a production rule, whose purpose
 is to transform a <em>parse tree</em> into an AST, making simplifications along the
-way — for example, by omitting whitespace (not to be confused with
+way --- for example, by omitting whitespace (not to be confused with
 <em>preprocessor</em>)</p>
 <p><strong>ambiguity</strong>: a situation where there exist more than one <em>derivations</em> for a
-single <em>string</em> — unlike most <em>parser</em> libraries, <em>nearley</em> returns all
+single <em>string</em> --- unlike most <em>parser</em> libraries, <em>nearley</em> returns all
 possible derivations</p>
 <p><strong>Earley algorithm</strong>: a <em>parsing</em> algorithm developed by Jay Earley in 1968,
 which can efficiently parse all <em>context-free grammars</em></p>
@@ -326,59 +328,65 @@ though it is not necessarily equal to the <em>epsilon</em> rule (for example, th
 <em>concatenation</em> of epsilon with epsilon)</p>
 <p><strong>nearley</strong>: a <em>parser</em> that parses <em>context-free languages</em>, along with
 several additional utilities for building languages</p>
-
+</body></html>
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
     href="http://hardmath123.github.io">Hardmath123</a> (<a
     href="http://github.com/Hardmath123">Github</a>). You're welcome to
     leave questions, comments, advice, or ideas as Github issues. And
     feel free to fork nearley with your own experiments!<br/>
-    
+
     <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
     <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
 </div>
 
-<script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>
-document.querySelector('#highlight-js').addEventListener('load', function() {
-    [].slice.apply(document.querySelectorAll('pre code')).forEach(function(b) {
-        hljs.highlightBlock(b)
-    })
-})
-</script>
-
 
 <script>
-window.addEventListener('scroll', onScroll)
-window.addEventListener('resize', onScroll)
+window.addEventListener("scroll", onScroll);
+window.addEventListener("resize", onScroll);
 
-var timeout
+var timeout;
 function onScroll(e) {
-    if (timeout) clearTimeout(timeout)
-    timeout = setTimeout(scrollEnd, 50)
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(scrollEnd, 50);
 }
 
 function scrollEnd() {
-  var headings = document.querySelectorAll('h3')
-  var offset = 60
-  for (var i=headings.length; i--; ) {
-    var h3 = headings[i]
+  var headings = document.querySelectorAll("h3");
+  var offset = 60;
+  for (var i = headings.length; i--; ) {
+    var h3 = headings[i];
     if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector('.page-heading-active')
-      if (cur) cur.className = 'page-heading'
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
-      return
+      var cur = document.querySelector(".page-heading-active");
+      if (cur) cur.className = "page-heading";
+      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
+        "page-heading page-heading-active";
+      return;
     }
   }
 }
 </script>
 
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-46120535-5', 'auto');
-ga('send', 'pageview');
+(function(i, s, o, g, r, a, m) {
+  i["GoogleAnalyticsObject"] = r;
+  (i[r] =
+    i[r] ||
+    function() {
+      (i[r].q = i[r].q || []).push(arguments);
+    }),
+    (i[r].l = 1 * new Date());
+  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+  a.async = 1;
+  a.src = g;
+  m.parentNode.insertBefore(a, m);
+})(
+  window,
+  document,
+  "script",
+  "https://www.google-analytics.com/analytics.js",
+  "ga"
+);
+ga("create", "UA-46120535-5", "auto");
+ga("send", "pageview");
 </script>
-

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <title>Glossary - nearley.js - JS Parsing Toolkit</title>
-<meta charset="utf-8"/>
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
-@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
+  @import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -145,11 +145,23 @@ code {
 
 pre code, .highlight pre {
     border-radius: 0.5em;
-    padding: 0.5em;
+    margin: 5px;
+    padding: 10px;
     display: block;
     overflow: auto;
 }
 
+.highlight pre {
+    padding: 0;
+    margin: 0;
+    display: block;
+    overflow-x: auto;
+}
+
+pre > code > pre > code {
+    padding: 0;
+    margin: 0;
+}
 
 ol {
     counter-reset: tutorial-counter;
@@ -206,7 +218,7 @@ nav ul a {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 0.25em 0.5em; */
+    padding: 0.25em 0.5em;
 }
 .page {
     display: block;
@@ -241,38 +253,89 @@ nav ul a {
     }
 }
 
-.highlight pre {
-  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+code pre {
+    margin: 0;
 }
-
 </style>
 
-<body class="docs-page">
+<body class="docs-page" >
 
-<a href="https://github.com/kach/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-<nav id="nav">
-    <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">2.12.1</span></a></h1>
+  <a href="https://github.com/kach/nearley" class="github-corner">
+    <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg>
+  </a>
+  <style>
+    .github-corner:hover .octo-arm {
+      animation: octocat-wave 560ms ease-in-out
+    }
+
+    @keyframes octocat-wave {
+      0%,
+      100% {
+        transform: rotate(0)
+      }
+      20%,
+      60% {
+        transform: rotate(-25deg)
+      }
+      40%,
+      80% {
+        transform: rotate(10deg)
+      }
+    }
+
+    @media (max-width:500px) {
+      .github-corner:hover .octo-arm {
+        animation: none
+      }
+      .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out
+      }
+    }
+  </style>
+  <nav id="nav">
+    <h1>
+      <a href="/">nearley
+        <span style="color: #559;">.js</span>
+        <span id="version">2.12.1</span>
+      </a>
+    </h1>
     <ul>
-        <li class="page"><a href="/docs/index">Home</a>
-        <li class="page"><a href="/docs/getting-started">Getting started</a>
-        <li class="page"><a href="/docs/grammar">Writing a parser</a>
-        <li class="page"><a href="/docs/parser">Using a parser</a>
-        <li class="page"><a href="/docs/tokenizers">Tokenizers</a>
-        <li class="page"><a href="/docs/tooling">Tooling</a>
-        <li class="page"><a href="/docs/how-to-grammar-good">How to grammar good</a>
-        <li class="page"><a href="/docs/using-in-frontend">Compiling in browsers</a>
-        <li class="page">
-            <a href="#" class="page-title-active">Glossary</a>
+               <li class="page">
+          <a href="/docs/index">Home</a>
+                    <li class="page">
+          <a href="/docs/getting-started">Getting started</a>
+                    <li class="page">
+          <a href="/docs/grammar">Writing a parser</a>
+                    <li class="page">
+          <a href="/docs/parser">Using a parser</a>
+                    <li class="page">
+          <a href="/docs/tokenizers">Tokenizers</a>
+                    <li class="page">
+          <a href="/docs/tooling">Tooling</a>
+                    <li class="page">
+          <a href="/docs/how-to-grammar-good">How to grammar good</a>
+                    <li class="page">
+          <a href="/docs/using-in-frontend">Compiling in browsers</a>
+            
+      <li class="page">
+        <a href="#" class="page-title-active">Glossary</a>
         </li>
+ 
     </ul>
-</nav>
+  </nav>
 
-<div id="main" class="center">
+  <div id="main" class="center">
 
-<h2>Glossary</h2>
-<html><head></head><body><p>Parsing terminology gets very confusing very quickly. Here is a glossary that
+    <h2>Glossary</h2>
+    <p>Parsing terminology gets very confusing very quickly. Here is a glossary that
 can help us all communicate more effectively.</p>
-<p><strong>token</strong>: the smallest meaningful unit (the &quot;words&quot;) of your language</p>
+<p><strong>token</strong>: the smallest meaningful unit (the “words”) of your language</p>
 <p><strong>lexer</strong>: a function that converts a sequence of <em>characters</em> to a sequence of
 <em>tokens</em> (converts a sequence of letters and spaces to a sequence of words)</p>
 <p><strong>string</strong>: a sequence of <em>tokens</em></p>
@@ -293,7 +356,7 @@ that match</p>
 <p><strong>Backus-Naur Form</strong>: a set of conventions for describing and typesetting
 context-free grammars</p>
 <p><strong>recognizer</strong>: a function that takes a <em>grammar</em> and a <em>string</em> and sees if
-the grammar matches the string (it just says &quot;yes&quot; or &quot;no&quot;)</p>
+the grammar matches the string (it just says “yes” or “no”)</p>
 <p><strong>parser</strong>: a function that takes a <em>grammar</em> and a <em>string</em> and returns a
 <em>derivation</em> of that string from that grammar</p>
 <p><strong>derivation</strong>: a way to apply the production rules of a <em>grammar</em> recursively
@@ -307,10 +370,10 @@ example, you can emit TypeScript code instead of plain JavaScript (not to be
 confused with <em>postprocessor</em>)</p>
 <p><strong>postprocessor</strong>: a function associated with a production rule, whose purpose
 is to transform a <em>parse tree</em> into an AST, making simplifications along the
-way --- for example, by omitting whitespace (not to be confused with
+way — for example, by omitting whitespace (not to be confused with
 <em>preprocessor</em>)</p>
 <p><strong>ambiguity</strong>: a situation where there exist more than one <em>derivations</em> for a
-single <em>string</em> --- unlike most <em>parser</em> libraries, <em>nearley</em> returns all
+single <em>string</em> — unlike most <em>parser</em> libraries, <em>nearley</em> returns all
 possible derivations</p>
 <p><strong>Earley algorithm</strong>: a <em>parsing</em> algorithm developed by Jay Earley in 1968,
 which can efficiently parse all <em>context-free grammars</em></p>
@@ -326,45 +389,50 @@ though it is not necessarily equal to the <em>epsilon</em> rule (for example, th
 <em>concatenation</em> of epsilon with epsilon)</p>
 <p><strong>nearley</strong>: a <em>parser</em> that parses <em>context-free languages</em>, along with
 several additional utilities for building languages</p>
-</body></html>
-
-    <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
-    href="http://hardmath123.github.io">Hardmath123</a> (<a
-    href="http://github.com/Hardmath123">Github</a>). You're welcome to
-    leave questions, comments, advice, or ideas as Github issues. And
-    feel free to fork nearley with your own experiments!<br/>
-
-    <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
-    <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
-</div>
 
 
-<script>
-window.addEventListener("scroll", onScroll);
-window.addEventListener("resize", onScroll);
+    <div id="footer">
+      <p>nearley is MIT-licensed. It's maintained by
+        <a href="http://hardmath123.github.io">Hardmath123</a> (
+        <a href="http://github.com/Hardmath123">Github</a>). You're welcome to leave questions, comments, advice, or ideas as Github issues. And feel free to fork
+        nearley with your own experiments!
+        <br/>
 
-var timeout;
-function onScroll(e) {
-  if (timeout) clearTimeout(timeout);
-  timeout = setTimeout(scrollEnd, 50);
-}
+        <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
+          <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo" />
+        </a>
+    </div>
 
-function scrollEnd() {
-  var headings = document.querySelectorAll("h3");
-  var offset = 60;
-  for (var i = headings.length; i--; ) {
-    var h3 = headings[i];
-    if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector(".page-heading-active");
-      if (cur) cur.className = "page-heading";
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
-        "page-heading page-heading-active";
-      return;
-    }
-  }
-}
-</script>
+    <script>
+      window.addEventListener('scroll', onScroll)
+      window.addEventListener('resize', onScroll)
+      var timeout
+      function onScroll(e) {
+        if (timeout) clearTimeout(timeout)
+        timeout = setTimeout(scrollEnd, 50)
+      }
+      function scrollEnd() {
+        var headings = document.querySelectorAll('h3')
+        var offset = 60
+        for (var i = headings.length; i--;) {
+          var h3 = headings[i]
+          if (h3.offsetTop < window.scrollY + offset) {
+            var cur = document.querySelector('.page-heading-active')
+            if (cur) cur.className = 'page-heading'
+            document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
+            return
+          }
+        }
+      }
+    </script>
 
-<script>
-(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
-</script>
+    <script>
+      (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-46120535-5', 'auto');
+      ga('send', 'pageview');
+    </script>

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -241,8 +241,6 @@ nav ul a {
     }
 }
 
-/* highlight.js */
-
 .highlight pre {
   display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
 }
@@ -368,25 +366,5 @@ function scrollEnd() {
 </script>
 
 <script>
-(function(i, s, o, g, r, a, m) {
-  i["GoogleAnalyticsObject"] = r;
-  (i[r] =
-    i[r] ||
-    function() {
-      (i[r].q = i[r].q || []).push(arguments);
-    }),
-    (i[r].l = 1 * new Date());
-  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-  a.async = 1;
-  a.src = g;
-  m.parentNode.insertBefore(a, m);
-})(
-  window,
-  document,
-  "script",
-  "https://www.google-analytics.com/analytics.js",
-  "ga"
-);
-ga("create", "UA-46120535-5", "auto");
-ga("send", "pageview");
+(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
 </script>

--- a/docs/grammar.html
+++ b/docs/grammar.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <title>Writing a parser - nearley.js - JS Parsing Toolkit</title>
-<meta charset="utf-8"/>
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
-@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
+  @import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -145,11 +145,23 @@ code {
 
 pre code, .highlight pre {
     border-radius: 0.5em;
-    padding: 0.5em;
+    margin: 5px;
+    padding: 10px;
     display: block;
     overflow: auto;
 }
 
+.highlight pre {
+    padding: 0;
+    margin: 0;
+    display: block;
+    overflow-x: auto;
+}
+
+pre > code > pre > code {
+    padding: 0;
+    margin: 0;
+}
 
 ol {
     counter-reset: tutorial-counter;
@@ -206,7 +218,7 @@ nav ul a {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 0.25em 0.5em; */
+    padding: 0.25em 0.5em;
 }
 .page {
     display: block;
@@ -241,105 +253,152 @@ nav ul a {
     }
 }
 
-.highlight pre {
-  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+code pre {
+    margin: 0;
 }
-
 </style>
 
-<body class="docs-page">
+<body class="docs-page" >
 
-<a href="https://github.com/kach/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-<nav id="nav">
-    <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">2.12.1</span></a></h1>
+  <a href="https://github.com/kach/nearley" class="github-corner">
+    <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg>
+  </a>
+  <style>
+    .github-corner:hover .octo-arm {
+      animation: octocat-wave 560ms ease-in-out
+    }
+
+    @keyframes octocat-wave {
+      0%,
+      100% {
+        transform: rotate(0)
+      }
+      20%,
+      60% {
+        transform: rotate(-25deg)
+      }
+      40%,
+      80% {
+        transform: rotate(10deg)
+      }
+    }
+
+    @media (max-width:500px) {
+      .github-corner:hover .octo-arm {
+        animation: none
+      }
+      .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out
+      }
+    }
+  </style>
+  <nav id="nav">
+    <h1>
+      <a href="/">nearley
+        <span style="color: #559;">.js</span>
+        <span id="version">2.12.1</span>
+      </a>
+    </h1>
     <ul>
-        <li class="page"><a href="/docs/index">Home</a>
-        <li class="page"><a href="/docs/getting-started">Getting started</a>
-        <li class="page">
-            <a href="#" class="page-title-active">Writing a parser</a>
-            <ul>
-                <li class="page-heading"><a href="#vocabulary">
-Vocabulary</a></li>
-                <li class="page-heading"><a href="#postprocessors">
-Postprocessors</a></li>
-                <li class="page-heading"><a href="#more-syntax-tips-and-tricks">
-More syntax: tips and tricks</a></li>
-                <li class="page-heading"><a href="#macros">
-Macros</a></li>
-                <li class="page-heading"><a href="#additional-js">
-Additional JS</a></li>
-                <li class="page-heading"><a href="#importing-other-grammars">
-Importing other grammars</a></li>
-                <li class="page-heading"><a href="#whats-next">
-What&#x27;s next?</a></li>
-            </ul>
+               <li class="page">
+          <a href="/docs/index">Home</a>
+                    <li class="page">
+          <a href="/docs/getting-started">Getting started</a>
+            
+      <li class="page">
+        <a href="#" class="page-title-active">Writing a parser</a>
+        <ul>
+          <li class="page-heading">
+            <a href="#vocabulary">Vocabulary</a>
+          <li class="page-heading">
+            <a href="#postprocessors">Postprocessors</a>
+          <li class="page-heading">
+            <a href="#more-syntax-tips-and-tricks">More syntax: tips and tricks</a>
+          <li class="page-heading">
+            <a href="#macros">Macros</a>
+          <li class="page-heading">
+            <a href="#additional-js">Additional JS</a>
+          <li class="page-heading">
+            <a href="#importing-other-grammars">Importing other grammars</a>
+          <li class="page-heading">
+            <a href="#what-s-next-">What’s next?</a>
+        </ul>
         </li>
-        <li class="page"><a href="/docs/parser">Using a parser</a>
-        <li class="page"><a href="/docs/tokenizers">Tokenizers</a>
-        <li class="page"><a href="/docs/tooling">Tooling</a>
-        <li class="page"><a href="/docs/how-to-grammar-good">How to grammar good</a>
-        <li class="page"><a href="/docs/using-in-frontend">Compiling in browsers</a>
-        <li class="page"><a href="/docs/glossary">Glossary</a>
+          <li class="page">
+          <a href="/docs/parser">Using a parser</a>
+                    <li class="page">
+          <a href="/docs/tokenizers">Tokenizers</a>
+                    <li class="page">
+          <a href="/docs/tooling">Tooling</a>
+                    <li class="page">
+          <a href="/docs/how-to-grammar-good">How to grammar good</a>
+                    <li class="page">
+          <a href="/docs/using-in-frontend">Compiling in browsers</a>
+                    <li class="page">
+          <a href="/docs/glossary">Glossary</a>
+           
     </ul>
-</nav>
+  </nav>
 
-<div id="main" class="center">
+  <div id="main" class="center">
 
-<h2>Writing a parser</h2>
-<html><head></head><body><p>This section describes the nearley grammar language, in which you can describe
+    <h2>Writing a parser</h2>
+    <p>This section describes the nearley grammar language, in which you can describe
 grammars for nearley to parse. Grammars are conventionally kept in <code>.ne</code> files.
 You can then use <code>nearleyc</code> to compile your <code>.ne</code> grammars to JavaScript
 modules.</p>
 <p>You can find many examples of nearley grammars online, as well as some in the
 <code>examples/</code> directory of the <a href="http://github.com/Hardmath123/nearley">Github
 repository</a>.</p>
-<h3 id="vocabulary">
-Vocabulary</h3>
+<h3 id="vocabulary">Vocabulary</h3>
 <ul>
 <li>A <em>terminal</em> is a single, constant string or a token. For example, the
 keyword <code>&quot;if&quot;</code> is a terminal.</li>
-<li>A <em>nonterminal</em> describes a set of possible strings. For example, all &quot;if&quot;
+<li>A <em>nonterminal</em> describes a set of possible strings. For example, all “if”
 statements can be described by a single nonterminal whose value depends on
 the condition and body of the if statement.</li>
-<li>A <em>rule</em> (or production rule) is a definition of a nonterminal. For example,
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">ifStatement</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;if&quot;</span> <span class="pl-en">condition</span> <span class="pl-s">&quot;then&quot;</span> <span class="pl-en">statement</span> <span class="pl-s">&quot;endif&quot;</span></pre></div>
+<li>A <em>rule</em> (or production rule) is a definition of a nonterminal. For example,<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">ifStatement</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;if&quot;</span> <span class="pl-en">condition</span> <span class="pl-s">&quot;then&quot;</span> <span class="pl-en">statement</span> <span class="pl-s">&quot;endif&quot;</span></pre></div></code></pre>
 is the rule according to which the if statement nonterminal, <code>ifStatement</code>,
 is parsed. It depends on the nonterminals <code>condition</code> and <code>statement</code>. A
 nonterminal can be described by multiple rules. For example, we can add a
-second rule
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">ifStatement</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;if&quot;</span> <span class="pl-en">condition</span> <span class="pl-s">&quot;then&quot;</span> <span class="pl-en">statement</span> <span class="pl-s">&quot;else&quot;</span> <span class="pl-en">statement</span> <span class="pl-s">&quot;endif&quot;</span></pre></div>
-to support &quot;else&quot; clauses.</li>
+second rule<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">ifStatement</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;if&quot;</span> <span class="pl-en">condition</span> <span class="pl-s">&quot;then&quot;</span> <span class="pl-en">statement</span> <span class="pl-s">&quot;else&quot;</span> <span class="pl-en">statement</span> <span class="pl-s">&quot;endif&quot;</span></pre></div></code></pre>
+to support “else” clauses.</li>
 </ul>
 <p>By default, nearley attempts to parse the first nonterminal defined in the
 grammar. In the following grammar, nearley will try to parse input text as an
 <code>expression</code>.</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span>
 <span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;-&quot;</span> <span class="pl-en">number</span>
 <span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;*&quot;</span> <span class="pl-en">number</span>
 <span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;/&quot;</span> <span class="pl-en">number</span>
-<span class="pl-en">number</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[0-9]</span><span class="pl-k">:+</span></pre></div>
+<span class="pl-en">number</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[0-9]</span><span class="pl-k">:+</span></pre></div></code></pre>
 <p>You can use the pipe character <code>|</code> to separate alternative rules for a
 nonterminal. In the example below, <code>expression</code> has four different rules.</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span>
     <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span>
   <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;-&quot;</span> <span class="pl-en">number</span>
   <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;*&quot;</span> <span class="pl-en">number</span>
-  <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;/&quot;</span> <span class="pl-en">number</span></pre></div>
+  <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;/&quot;</span> <span class="pl-en">number</span></pre></div></code></pre>
 <p>The keyword <code>null</code> stands for the <strong>epsilon rule</strong>, which matches nothing. The
 following nonterminal matches zero or more <code>cow</code>s in a row, such as
 <code>cowcowcow</code>:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">a</span> <span class="pl-k">-&gt;</span> <span class="pl-c1">null</span> <span class="pl-k">|</span> <span class="pl-en">a</span> <span class="pl-s">&quot;cow&quot;</span></pre></div>
-<h3 id="postprocessors">
-Postprocessors</h3>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">a</span> <span class="pl-k">-&gt;</span> <span class="pl-c1">null</span> <span class="pl-k">|</span> <span class="pl-en">a</span> <span class="pl-s">&quot;cow&quot;</span></pre></div></code></pre>
+<h3 id="postprocessors">Postprocessors</h3>
 <p>By default, nearley wraps everything matched by a rule into an array. For
 example, when <code>rule -&gt; &quot;tick&quot; &quot;tock&quot;</code> matches the string <code>&quot;ticktock&quot;</code>, it
-creates the &quot;parse tree&quot; <code>[&quot;tick&quot;, &quot;tock&quot;]</code>. Most of the time, however, you
+creates the “parse tree” <code>[&quot;tick&quot;, &quot;tock&quot;]</code>. Most of the time, however, you
 need to process that data in some way: for example, you may want to filter out
 whitespace, or transform the results into a custom JavaScript object.</p>
 <p>For this purpose, each rule can have a <em>postprocessor</em>: a JavaScript function
-that transforms the array and returns a &quot;processed&quot; version of the result.
+that transforms the array and returns a “processed” version of the result.
 Postprocessors are wrapped in <code>{% %}</code>s:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span> <span class="pl-c">{%</span>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span> <span class="pl-c">{%</span>
     <span class="pl-k">function</span>(<span class="pl-smi">data</span>) {
         <span class="pl-k">return</span> {
             operator<span class="pl-k">:</span> <span class="pl-s"><span class="pl-pds">&quot;</span>sum<span class="pl-pds">&quot;</span></span>,
@@ -347,25 +406,25 @@ Postprocessors are wrapped in <code>{% %}</code>s:</p>
             rightOperand<span class="pl-k">:</span> data[<span class="pl-c1">2</span>] <span class="pl-c"><span class="pl-c">//</span> data[1] is &quot;+&quot;</span>
         };
     }
-<span class="pl-c">%}</span></pre></div>
-<p>The rule above will parse the string <code>5+10</code> into <code>{ operator: &quot;sum&quot;, leftOperand: 5, rightOperand: 10 }</code>.</p>
-<p>The postprocessor can be any function with signature <code>function(data, location, reject)</code>. Here,</p>
+<span class="pl-c">%}</span></pre></div></code></pre>
+<p>The rule above will parse the string <code>5+10</code> into <code>{ operator: &quot;sum&quot;,
+leftOperand: 5, rightOperand: 10 }</code>.</p>
+<p>The postprocessor can be any function with signature <code>function(data, location,
+reject)</code>. Here,</p>
 <ul>
-<li>
-<p><code>data: Array</code> is an array that contains the results of parsing each part of
+<li><p><code>data: Array</code> is an array that contains the results of parsing each part of
 the rule. Note that it is still an array, even if the rule only has one part!
 You can use the built-in <code>{% id %}</code> postprocessor to convert a one-item array
 into the item itself.</p>
 <p>For <strong>arrow function</strong> users, a convenient pattern is to decompose the <code>data</code>
 array within the argument of the arrow function:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span>
     <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span> <span class="pl-c">{%</span> ([<span class="pl-smi">fst</span>, <span class="pl-smi">_</span>, <span class="pl-smi">snd</span>]) <span class="pl-k">=&gt;</span> fst <span class="pl-k">+</span> snd <span class="pl-c">%}</span>
   <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;-&quot;</span> <span class="pl-en">number</span> <span class="pl-c">{%</span> ([<span class="pl-smi">fst</span>, <span class="pl-smi">_</span>, <span class="pl-smi">snd</span>]) <span class="pl-k">=&gt;</span> fst <span class="pl-k">-</span> snd <span class="pl-c">%}</span>
   <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;*&quot;</span> <span class="pl-en">number</span> <span class="pl-c">{%</span> ([<span class="pl-smi">fst</span>, <span class="pl-smi">_</span>, <span class="pl-smi">snd</span>]) <span class="pl-k">=&gt;</span> fst <span class="pl-k">*</span> snd <span class="pl-c">%}</span>
-  <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;/&quot;</span> <span class="pl-en">number</span> <span class="pl-c">{%</span> ([<span class="pl-smi">fst</span>, <span class="pl-smi">_</span>, <span class="pl-smi">snd</span>]) <span class="pl-k">=&gt;</span> fst <span class="pl-k">/</span> snd <span class="pl-c">%}</span></pre></div>
+  <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;/&quot;</span> <span class="pl-en">number</span> <span class="pl-c">{%</span> ([<span class="pl-smi">fst</span>, <span class="pl-smi">_</span>, <span class="pl-smi">snd</span>]) <span class="pl-k">=&gt;</span> fst <span class="pl-k">/</span> snd <span class="pl-c">%}</span></pre></div></code></pre>
 </li>
-<li>
-<p><code>location: number</code> is the index (zero-based) at which the rule match starts.
+<li><p><code>location: number</code> is the index (zero-based) at which the rule match starts.
 You might use this to show the location of an expression in an error message.</p>
 <blockquote>
 <p>Note: Many <a href="tokenizers">tokenizers</a> provide line, column, and offset
@@ -375,13 +434,12 @@ would only tell you that it saw the nth <em>token</em> rather than the nth
 <em>character</em> in the string.</p>
 </blockquote>
 </li>
-<li>
-<p><code>reject: Object</code> is a unique object that you can return to signal that this
-rule doesn&apos;t <em>actually</em> match its input.</p>
+<li><p><code>reject: Object</code> is a unique object that you can return to signal that this
+rule doesn’t <em>actually</em> match its input.</p>
 <p>Reject is used in some edge cases. For example, suppose you want sequences of
 letters to match variables, except for the keyword <code>if</code>. In this case, your
 rule may be</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">variable</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[a-z]</span><span class="pl-k">:+</span> <span class="pl-c">{%</span>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">variable</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[a-z]</span><span class="pl-k">:+</span> <span class="pl-c">{%</span>
     <span class="pl-k">function</span>(<span class="pl-smi">d</span>,<span class="pl-smi">l</span>, <span class="pl-smi">reject</span>) {
         <span class="pl-k">if</span> (d[<span class="pl-c1">0</span>] <span class="pl-k">==</span> <span class="pl-s"><span class="pl-pds">&apos;</span>if<span class="pl-pds">&apos;</span></span>) {
             <span class="pl-k">return</span> reject;
@@ -389,7 +447,7 @@ rule may be</p>
             <span class="pl-k">return</span> {<span class="pl-s"><span class="pl-pds">&apos;</span>name<span class="pl-pds">&apos;</span></span><span class="pl-k">:</span> d[<span class="pl-c1">0</span>]};
         }
     }
-<span class="pl-c">%}</span></pre></div>
+<span class="pl-c">%}</span></pre></div></code></pre>
 <blockquote>
 <p>Warning: Grammars using <code>reject</code> are not context-free, and are often much
 slower to parse. So, we encourage you not to use <code>reject</code> unless absolutely
@@ -399,138 +457,134 @@ necessary. You can usually use a tokenizer instead.</p>
 </ul>
 <p>nearley provides two built-in postprocessors for the most common scenarios:</p>
 <ul>
-<li>
-<code>id</code> returns the first element of the <code>data</code> array. This is useful to
-extract the content of a single-element array: <code>foo -&gt; bar {% id %}</code>
-</li>
-<li>
-<code>nuller</code> returns the JavaScript <code>null</code> value. This is useful for whitespace
-rules: <code>space -&gt; &quot; &quot; {% nuller %}</code>
-</li>
+<li><code>id</code> returns the first element of the <code>data</code> array. This is useful to
+extract the content of a single-element array: <code>foo -&gt; bar {% id %}</code></li>
+<li><code>nuller</code> returns the JavaScript <code>null</code> value. This is useful for whitespace
+rules: <code>space -&gt; &quot; &quot; {% nuller %}</code></li>
 </ul>
-<h3 id="more-syntax-tips-and-tricks">
-More syntax: tips and tricks</h3>
-<h4>
-<a id="user-content-comments" class="anchor" href="#comments" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Comments</h4>
-<p>Comments are marked with &apos;#&apos;. Everything from <code>#</code> to the end of a line is
+<h3 id="more-syntax-tips-and-tricks">More syntax: tips and tricks</h3>
+<h4 id="comments">Comments</h4>
+<p>Comments are marked with ‘#’. Everything from <code>#</code> to the end of a line is
 ignored:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span> <span class="pl-c"># sum of two numbers</span></pre></div>
-<h4>
-<a id="user-content-charsets" class="anchor" href="#charsets" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Charsets</h4>
-<p>You can use valid RegExp charsets in a rule (unless you&apos;re using a
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span> <span class="pl-c"># sum of two numbers</span></pre></div></code></pre>
+<h4 id="charsets">Charsets</h4>
+<p>You can use valid RegExp charsets in a rule (unless you’re using a
 <a href="tokenizers">tokenizer</a>):</p>
-<pre><code>not_a_letter -&gt; [^a-zA-Z]
-</code></pre>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">not_a_letter</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[^a-zA-Z]</span></pre></div></code></pre>
 <p>The <code>.</code> character can be used to represent any character.</p>
-<h4>
-<a id="user-content-case-insensitive-string-literals" class="anchor" href="#case-insensitive-string-literals" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Case-insensitive string literals</h4>
+<h4 id="case-insensitive-string-literals">Case-insensitive string literals</h4>
 <p>You can create case-insensitive string literals by adding an <code>i</code> after the
 string literal:</p>
-<pre><code>cow -&gt; &quot;cow&quot;i # matches CoW, COW, and so on.
-</code></pre>
-<p>Note that if you are using a lexer, your lexer should use the <code>i</code> flag in its
-regexes instead. That is, if you are using a lexer, you should <em>not</em> use the
-<code>i</code> suffix in nearley.</p>
-<h4>
-<a id="user-content-ebnf" class="anchor" href="#ebnf" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>EBNF</h4>
-<p>nearley supports the <code>*</code>, <code>?</code>, and <code>+</code> operators from
-<a href="https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form" rel="nofollow">EBNF</a> as shown:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">batman</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;na&quot;</span><span class="pl-k">:*</span> <span class="pl-s">&quot;batman&quot;</span> <span class="pl-c"># nananana...nanabatman</span></pre></div>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">cow</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;cow&quot;</span><span class="pl-en">i</span> <span class="pl-c"># matches CoW, COW, and so on.</span>
+```<span class="pl-en">ne</span>
+
+<span class="pl-en">Note</span> <span class="pl-en">that</span> <span class="pl-en">if</span> <span class="pl-en">you</span> <span class="pl-en">are</span> <span class="pl-en">using</span> <span class="pl-en">a</span> <span class="pl-en">lexer</span>, <span class="pl-en">your</span> <span class="pl-en">lexer</span> <span class="pl-en">should</span> <span class="pl-en">use</span> <span class="pl-en">the</span> `<span class="pl-en">i</span>` <span class="pl-en">flag</span> <span class="pl-en">in</span> <span class="pl-en">its</span>
+<span class="pl-en">regexes</span> <span class="pl-en">instead</span>. <span class="pl-en">That</span> <span class="pl-en">is</span>, <span class="pl-en">if</span> <span class="pl-en">you</span> <span class="pl-en">are</span> <span class="pl-en">using</span> <span class="pl-en">a</span> <span class="pl-en">lexer</span>, <span class="pl-en">you</span> <span class="pl-en">should</span> *<span class="pl-en">not</span>* <span class="pl-en">use</span> <span class="pl-en">the</span>
+`<span class="pl-en">i</span>` <span class="pl-en">suffix</span> <span class="pl-en">in</span> <span class="pl-en">nearley</span>.
+
+<span class="pl-c">#### EBNF</span>
+
+<span class="pl-en">nearley</span> <span class="pl-en">supports</span> <span class="pl-en">the</span> `*`, `<span class="pl-en">?</span>`, <span class="pl-en">and</span> `<span class="pl-en">+</span>` <span class="pl-en">operators</span> <span class="pl-en">from</span>
+<span class="pl-s">[EBNF]</span><span class="pl-k">(</span><span class="pl-en">https</span>://<span class="pl-en">en</span>.<span class="pl-en">wikipedia</span>.<span class="pl-en">org</span>/<span class="pl-en">wiki</span>/<span class="pl-en">Extended_Backus</span>&#x2013;<span class="pl-en">Naur_form</span><span class="pl-k">)</span> <span class="pl-en">as</span> <span class="pl-en">shown</span>:
+
+```<span class="pl-en">ne</span>
+<span class="pl-en">batman</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;na&quot;</span><span class="pl-k">:*</span> <span class="pl-s">&quot;batman&quot;</span> <span class="pl-c"># nananana...nanabatman</span></pre></div></code></pre>
 <p>You can also use capture groups with parentheses. Its contents can be anything
 that a rule can have:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">banana</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;ba&quot;</span> <span class="pl-k">(</span><span class="pl-s">&quot;na&quot;</span> <span class="pl-c">{%</span> id <span class="pl-c">%}</span> <span class="pl-k">|</span> <span class="pl-s">&quot;NA&quot;</span> <span class="pl-c">{%</span> id <span class="pl-c">%}</span><span class="pl-k">):+</span></pre></div>
-<h3 id="macros">
-Macros</h3>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">banana</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;ba&quot;</span> <span class="pl-k">(</span><span class="pl-s">&quot;na&quot;</span> <span class="pl-c">{%</span> id <span class="pl-c">%}</span> <span class="pl-k">|</span> <span class="pl-s">&quot;NA&quot;</span> <span class="pl-c">{%</span> id <span class="pl-c">%}</span><span class="pl-k">):+</span></pre></div></code></pre>
+<h3 id="macros">Macros</h3>
 <p>Macros allow you to create polymorphic rules:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-c"># Matches &quot;&apos;Hello?&apos; &apos;Hello?&apos; &apos;Hello?&apos;&quot;</span>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-c"># Matches &quot;&apos;Hello?&apos; &apos;Hello?&apos; &apos;Hello?&apos;&quot;</span>
 <span class="pl-en">matchThree</span><span class="pl-v">[X]</span> <span class="pl-k">-&gt;</span> <span class="pl-v">$X</span> <span class="pl-s">&quot; &quot;</span> <span class="pl-v">$X</span> <span class="pl-s">&quot; &quot;</span> <span class="pl-v">$X</span>
 <span class="pl-en">inQuotes</span><span class="pl-v">[X]</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;&apos;&quot;</span> <span class="pl-v">$X</span> <span class="pl-s">&quot;&apos;&quot;</span>
 
-<span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-en">matchThree[inQuotes[</span><span class="pl-s">&quot;Hello?&quot;</span><span class="pl-en">]]</span></pre></div>
+<span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-en">matchThree[inQuotes[</span><span class="pl-s">&quot;Hello?&quot;</span><span class="pl-en">]]</span></pre></div></code></pre>
 <p>Macros are dynamically scoped, which means they see arguments passed to parent
 macros:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-c"># Matches &quot;Cows oink.&quot; and &quot;Cows moo!&quot;</span>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-c"># Matches &quot;Cows oink.&quot; and &quot;Cows moo!&quot;</span>
 <span class="pl-en">sentence</span><span class="pl-v">[ANIMAL, PUNCTUATION]</span> <span class="pl-k">-&gt;</span> <span class="pl-en">animalGoes[</span><span class="pl-k">(</span><span class="pl-s">&quot;moo&quot;</span> <span class="pl-k">|</span> <span class="pl-s">&quot;oink&quot;</span> <span class="pl-k">|</span> <span class="pl-s">&quot;baa&quot;</span><span class="pl-k">)</span><span class="pl-en">]</span> <span class="pl-v">$PUNCTUATION</span>
 <span class="pl-en">animalGoes</span><span class="pl-v">[SOUND]</span> <span class="pl-k">-&gt;</span> <span class="pl-v">$ANIMAL</span> <span class="pl-s">&quot; &quot;</span> <span class="pl-v">$SOUND</span> <span class="pl-c"># uses $ANIMAL from its caller</span>
 
-<span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-en">sentence[</span><span class="pl-s">&quot;Cows&quot;</span>, <span class="pl-k">(</span><span class="pl-s">&quot;.&quot;</span> <span class="pl-k">|</span> <span class="pl-s">&quot;!&quot;</span><span class="pl-k">)</span><span class="pl-en">]</span></pre></div>
+<span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-en">sentence[</span><span class="pl-s">&quot;Cows&quot;</span>, <span class="pl-k">(</span><span class="pl-s">&quot;.&quot;</span> <span class="pl-k">|</span> <span class="pl-s">&quot;!&quot;</span><span class="pl-k">)</span><span class="pl-en">]</span></pre></div></code></pre>
 <p>Macros are expanded at compile time and inserted in places they are used. They
-are not &quot;real&quot; rules. Therefore, macros <em>cannot</em> be recursive (<code>nearleyc</code> will
+are not “real” rules. Therefore, macros <em>cannot</em> be recursive (<code>nearleyc</code> will
 go into an infinite loop trying to expand the macro-loop). They must also be
 defined <em>before</em> they are used.</p>
-<h3 id="additional-js">
-Additional JS</h3>
+<h3 id="additional-js">Additional JS</h3>
 <p>For more intricate postprocessors, or any other functionality you may need, you
 can include chunks of JavaScript code between production rules by surrounding
 it with <code>@{% ... %}</code>:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-c">@{%</span>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-c">@{%</span>
 <span class="pl-k">const</span> <span class="pl-c1">cowSays</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>./cow.js<span class="pl-pds">&quot;</span></span>);
 <span class="pl-c">%}</span>
 
-<span class="pl-en">cow</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;moo&quot;</span> <span class="pl-c">{%</span> ([<span class="pl-smi">moo</span>]) <span class="pl-k">=&gt;</span> <span class="pl-en">cowSays</span>(moo) <span class="pl-c">%}</span></pre></div>
-<p>Note that it doesn&apos;t matter where you add these; they all get hoisted to the
+<span class="pl-en">cow</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;moo&quot;</span> <span class="pl-c">{%</span> ([<span class="pl-smi">moo</span>]) <span class="pl-k">=&gt;</span> <span class="pl-en">cowSays</span>(moo) <span class="pl-c">%}</span></pre></div></code></pre>
+<p>Note that it doesn’t matter where you add these; they all get hoisted to the
 top of the generated code.</p>
-<h3 id="importing-other-grammars">
-Importing other grammars</h3>
+<h3 id="importing-other-grammars">Importing other grammars</h3>
 <p>You can include the content of other grammar files:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-k">@include</span> <span class="pl-s">&quot;../misc/primitives.ne&quot;</span> <span class="pl-c"># path relative to file being compiled</span>
-<span class="pl-en">sum</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span> <span class="pl-c"># uses &quot;number&quot; from the included file</span></pre></div>
-<p>There are some common nonterminals like &quot;integer&quot; and &quot;double-quoted string&quot;
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-k">@include</span> <span class="pl-s">&quot;../misc/primitives.ne&quot;</span> <span class="pl-c"># path relative to file being compiled</span>
+<span class="pl-en">sum</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span> <span class="pl-c"># uses &quot;number&quot; from the included file</span></pre></div></code></pre>
+<p>There are some common nonterminals like “integer” and “double-quoted string”
 that ship with nearley to help you prototype grammars efficiently. You can
 include them using the <code>@builtin</code> directive:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-k">@builtin</span> <span class="pl-s">&quot;number.ne&quot;</span>
-<span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-en">int</span><span class="pl-k">:+</span></pre></div>
-<p>(Note that we mean &quot;efficient&quot; in the sense that you can get them set up very
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-k">@builtin</span> <span class="pl-s">&quot;number.ne&quot;</span>
+<span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-en">int</span><span class="pl-k">:+</span></pre></div></code></pre>
+<p>(Note that we mean “efficient” in the sense that you can get them set up very
 quickly. The builtins are <em>inefficient</em> in the sense that they make your parser
-slower. For a &quot;real&quot; project, you would want to switch to a lexer and implement
+slower. For a “real” project, you would want to switch to a lexer and implement
 these primitives yourself!)</p>
 <p>See the <a href="https://github.com/kach/nearley/tree/master/builtin"><code>builtin/</code></a> directory on Github for more details. Contributions are
 welcome!</p>
 <p>Note that including a file imports <em>all</em> of the nonterminals defined in it, as
 well as any JS, macros, and configuration options defined there.</p>
-<h3 id="whats-next">
-What&apos;s next?</h3>
-<p>Now that you have a grammar, you&apos;re ready to <a href="parser">learn how to use it to build a
+<h3 id="what-s-next-">What’s next?</h3>
+<p>Now that you have a grammar, you’re ready to <a href="parser">learn how to use it to build a
 parser!</a></p>
-</body></html>
-
-    <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
-    href="http://hardmath123.github.io">Hardmath123</a> (<a
-    href="http://github.com/Hardmath123">Github</a>). You're welcome to
-    leave questions, comments, advice, or ideas as Github issues. And
-    feel free to fork nearley with your own experiments!<br/>
-
-    <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
-    <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
-</div>
 
 
-<script>
-window.addEventListener("scroll", onScroll);
-window.addEventListener("resize", onScroll);
+    <div id="footer">
+      <p>nearley is MIT-licensed. It's maintained by
+        <a href="http://hardmath123.github.io">Hardmath123</a> (
+        <a href="http://github.com/Hardmath123">Github</a>). You're welcome to leave questions, comments, advice, or ideas as Github issues. And feel free to fork
+        nearley with your own experiments!
+        <br/>
 
-var timeout;
-function onScroll(e) {
-  if (timeout) clearTimeout(timeout);
-  timeout = setTimeout(scrollEnd, 50);
-}
+        <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
+          <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo" />
+        </a>
+    </div>
 
-function scrollEnd() {
-  var headings = document.querySelectorAll("h3");
-  var offset = 60;
-  for (var i = headings.length; i--; ) {
-    var h3 = headings[i];
-    if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector(".page-heading-active");
-      if (cur) cur.className = "page-heading";
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
-        "page-heading page-heading-active";
-      return;
-    }
-  }
-}
-</script>
+    <script>
+      window.addEventListener('scroll', onScroll)
+      window.addEventListener('resize', onScroll)
+      var timeout
+      function onScroll(e) {
+        if (timeout) clearTimeout(timeout)
+        timeout = setTimeout(scrollEnd, 50)
+      }
+      function scrollEnd() {
+        var headings = document.querySelectorAll('h3')
+        var offset = 60
+        for (var i = headings.length; i--;) {
+          var h3 = headings[i]
+          if (h3.offsetTop < window.scrollY + offset) {
+            var cur = document.querySelector('.page-heading-active')
+            if (cur) cur.className = 'page-heading'
+            document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
+            return
+          }
+        }
+      }
+    </script>
 
-<script>
-(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
-</script>
+    <script>
+      (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-46120535-5', 'auto');
+      ga('send', 'pageview');
+    </script>

--- a/docs/grammar.html
+++ b/docs/grammar.html
@@ -4,6 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
+@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -142,7 +143,7 @@ code {
     background-color: #eee;
 }
 
-pre code {
+pre code, .highlight pre {
     border-radius: 0.5em;
     padding: 0.5em;
     display: block;
@@ -242,8 +243,9 @@ nav ul a {
 
 /* highlight.js */
 
-.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
-
+.highlight pre {
+  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+}
 
 </style>
 
@@ -258,13 +260,20 @@ nav ul a {
         <li class="page">
             <a href="#" class="page-title-active">Writing a parser</a>
             <ul>
-                <li class="page-heading"><a href="#vocabulary">Vocabulary</a>
-                <li class="page-heading"><a href="#postprocessors">Postprocessors</a>
-                <li class="page-heading"><a href="#more-syntax-tips-and-tricks">More syntax: tips and tricks</a>
-                <li class="page-heading"><a href="#macros">Macros</a>
-                <li class="page-heading"><a href="#additional-js">Additional JS</a>
-                <li class="page-heading"><a href="#importing-other-grammars">Importing other grammars</a>
-                <li class="page-heading"><a href="#what-s-next-">What’s next?</a>
+                <li class="page-heading"><a href="#vocabulary">
+Vocabulary</a></li>
+                <li class="page-heading"><a href="#postprocessors">
+Postprocessors</a></li>
+                <li class="page-heading"><a href="#more-syntax-tips-and-tricks">
+More syntax: tips and tricks</a></li>
+                <li class="page-heading"><a href="#macros">
+Macros</a></li>
+                <li class="page-heading"><a href="#additional-js">
+Additional JS</a></li>
+                <li class="page-heading"><a href="#importing-other-grammars">
+Importing other grammars</a></li>
+                <li class="page-heading"><a href="#whats-next">
+What&#x27;s next?</a></li>
             </ul>
         </li>
         <li class="page"><a href="/docs/parser">Using a parser</a>
@@ -279,89 +288,86 @@ nav ul a {
 <div id="main" class="center">
 
 <h2>Writing a parser</h2>
-<p>This section describes the nearley grammar language, in which you can describe
+<html><head></head><body><p>This section describes the nearley grammar language, in which you can describe
 grammars for nearley to parse. Grammars are conventionally kept in <code>.ne</code> files.
 You can then use <code>nearleyc</code> to compile your <code>.ne</code> grammars to JavaScript
 modules.</p>
 <p>You can find many examples of nearley grammars online, as well as some in the
 <code>examples/</code> directory of the <a href="http://github.com/Hardmath123/nearley">Github
 repository</a>.</p>
-<h3 id="vocabulary">Vocabulary</h3>
+<h3 id="vocabulary">
+Vocabulary</h3>
 <ul>
 <li>A <em>terminal</em> is a single, constant string or a token. For example, the
 keyword <code>&quot;if&quot;</code> is a terminal.</li>
-<li>A <em>nonterminal</em> describes a set of possible strings. For example, all “if”
+<li>A <em>nonterminal</em> describes a set of possible strings. For example, all &quot;if&quot;
 statements can be described by a single nonterminal whose value depends on
 the condition and body of the if statement.</li>
-<li>A <em>rule</em> (or production rule) is a definition of a nonterminal. For example,<pre><code class="lang-ne">ifStatement -&gt; &quot;if&quot; condition &quot;then&quot; statement &quot;endif&quot;
-</code></pre>
+<li>A <em>rule</em> (or production rule) is a definition of a nonterminal. For example,
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">ifStatement</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;if&quot;</span> <span class="pl-en">condition</span> <span class="pl-s">&quot;then&quot;</span> <span class="pl-en">statement</span> <span class="pl-s">&quot;endif&quot;</span></pre></div>
 is the rule according to which the if statement nonterminal, <code>ifStatement</code>,
 is parsed. It depends on the nonterminals <code>condition</code> and <code>statement</code>. A
 nonterminal can be described by multiple rules. For example, we can add a
-second rule<pre><code class="lang-ne">ifStatement -&gt; &quot;if&quot; condition &quot;then&quot; statement &quot;else&quot; statement &quot;endif&quot;
-</code></pre>
-to support “else” clauses.</li>
+second rule
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">ifStatement</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;if&quot;</span> <span class="pl-en">condition</span> <span class="pl-s">&quot;then&quot;</span> <span class="pl-en">statement</span> <span class="pl-s">&quot;else&quot;</span> <span class="pl-en">statement</span> <span class="pl-s">&quot;endif&quot;</span></pre></div>
+to support &quot;else&quot; clauses.</li>
 </ul>
 <p>By default, nearley attempts to parse the first nonterminal defined in the
 grammar. In the following grammar, nearley will try to parse input text as an
 <code>expression</code>.</p>
-<pre><code class="lang-ne">expression -&gt; number &quot;+&quot; number
-expression -&gt; number &quot;-&quot; number
-expression -&gt; number &quot;*&quot; number
-expression -&gt; number &quot;/&quot; number
-number -&gt; [0-9]:+
-</code></pre>
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span>
+<span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;-&quot;</span> <span class="pl-en">number</span>
+<span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;*&quot;</span> <span class="pl-en">number</span>
+<span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;/&quot;</span> <span class="pl-en">number</span>
+<span class="pl-en">number</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[0-9]</span><span class="pl-k">:+</span></pre></div>
 <p>You can use the pipe character <code>|</code> to separate alternative rules for a
 nonterminal. In the example below, <code>expression</code> has four different rules.</p>
-<pre><code class="lang-ne">expression -&gt;
-    number &quot;+&quot; number
-  | number &quot;-&quot; number
-  | number &quot;*&quot; number
-  | number &quot;/&quot; number
-</code></pre>
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span>
+    <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span>
+  <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;-&quot;</span> <span class="pl-en">number</span>
+  <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;*&quot;</span> <span class="pl-en">number</span>
+  <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;/&quot;</span> <span class="pl-en">number</span></pre></div>
 <p>The keyword <code>null</code> stands for the <strong>epsilon rule</strong>, which matches nothing. The
 following nonterminal matches zero or more <code>cow</code>s in a row, such as
 <code>cowcowcow</code>:</p>
-<pre><code class="lang-ne">a -&gt; null | a &quot;cow&quot;
-</code></pre>
-<h3 id="postprocessors">Postprocessors</h3>
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">a</span> <span class="pl-k">-&gt;</span> <span class="pl-c1">null</span> <span class="pl-k">|</span> <span class="pl-en">a</span> <span class="pl-s">&quot;cow&quot;</span></pre></div>
+<h3 id="postprocessors">
+Postprocessors</h3>
 <p>By default, nearley wraps everything matched by a rule into an array. For
 example, when <code>rule -&gt; &quot;tick&quot; &quot;tock&quot;</code> matches the string <code>&quot;ticktock&quot;</code>, it
-creates the “parse tree” <code>[&quot;tick&quot;, &quot;tock&quot;]</code>. Most of the time, however, you
+creates the &quot;parse tree&quot; <code>[&quot;tick&quot;, &quot;tock&quot;]</code>. Most of the time, however, you
 need to process that data in some way: for example, you may want to filter out
 whitespace, or transform the results into a custom JavaScript object.</p>
 <p>For this purpose, each rule can have a <em>postprocessor</em>: a JavaScript function
-that transforms the array and returns a “processed” version of the result.
+that transforms the array and returns a &quot;processed&quot; version of the result.
 Postprocessors are wrapped in <code>{% %}</code>s:</p>
-<pre><code class="lang-ne">expression -&gt; number &quot;+&quot; number {%
-    function(data) {
-        return {
-            operator: &quot;sum&quot;,
-            leftOperand:  data[0],
-            rightOperand: data[2] // data[1] is &quot;+&quot;
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span> <span class="pl-c">{%</span>
+    <span class="pl-k">function</span>(<span class="pl-smi">data</span>) {
+        <span class="pl-k">return</span> {
+            operator<span class="pl-k">:</span> <span class="pl-s"><span class="pl-pds">&quot;</span>sum<span class="pl-pds">&quot;</span></span>,
+            leftOperand<span class="pl-k">:</span>  data[<span class="pl-c1">0</span>],
+            rightOperand<span class="pl-k">:</span> data[<span class="pl-c1">2</span>] <span class="pl-c"><span class="pl-c">//</span> data[1] is &quot;+&quot;</span>
         };
     }
-%}
-</code></pre>
-<p>The rule above will parse the string <code>5+10</code> into <code>{ operator: &quot;sum&quot;,
-leftOperand: 5, rightOperand: 10 }</code>.</p>
-<p>The postprocessor can be any function with signature <code>function(data, location,
-reject)</code>. Here,</p>
+<span class="pl-c">%}</span></pre></div>
+<p>The rule above will parse the string <code>5+10</code> into <code>{ operator: &quot;sum&quot;, leftOperand: 5, rightOperand: 10 }</code>.</p>
+<p>The postprocessor can be any function with signature <code>function(data, location, reject)</code>. Here,</p>
 <ul>
-<li><p><code>data: Array</code> is an array that contains the results of parsing each part of
+<li>
+<p><code>data: Array</code> is an array that contains the results of parsing each part of
 the rule. Note that it is still an array, even if the rule only has one part!
 You can use the built-in <code>{% id %}</code> postprocessor to convert a one-item array
 into the item itself.</p>
 <p>For <strong>arrow function</strong> users, a convenient pattern is to decompose the <code>data</code>
 array within the argument of the arrow function:</p>
-<pre><code class="lang-ne">expression -&gt;
-    number &quot;+&quot; number {% ([fst, _, snd]) =&gt; fst + snd %}
-  | number &quot;-&quot; number {% ([fst, _, snd]) =&gt; fst - snd %}
-  | number &quot;*&quot; number {% ([fst, _, snd]) =&gt; fst * snd %}
-  | number &quot;/&quot; number {% ([fst, _, snd]) =&gt; fst / snd %}
-</code></pre>
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span>
+    <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span> <span class="pl-c">{%</span> ([<span class="pl-smi">fst</span>, <span class="pl-smi">_</span>, <span class="pl-smi">snd</span>]) <span class="pl-k">=&gt;</span> fst <span class="pl-k">+</span> snd <span class="pl-c">%}</span>
+  <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;-&quot;</span> <span class="pl-en">number</span> <span class="pl-c">{%</span> ([<span class="pl-smi">fst</span>, <span class="pl-smi">_</span>, <span class="pl-smi">snd</span>]) <span class="pl-k">=&gt;</span> fst <span class="pl-k">-</span> snd <span class="pl-c">%}</span>
+  <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;*&quot;</span> <span class="pl-en">number</span> <span class="pl-c">{%</span> ([<span class="pl-smi">fst</span>, <span class="pl-smi">_</span>, <span class="pl-smi">snd</span>]) <span class="pl-k">=&gt;</span> fst <span class="pl-k">*</span> snd <span class="pl-c">%}</span>
+  <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-s">&quot;/&quot;</span> <span class="pl-en">number</span> <span class="pl-c">{%</span> ([<span class="pl-smi">fst</span>, <span class="pl-smi">_</span>, <span class="pl-smi">snd</span>]) <span class="pl-k">=&gt;</span> fst <span class="pl-k">/</span> snd <span class="pl-c">%}</span></pre></div>
 </li>
-<li><p><code>location: number</code> is the index (zero-based) at which the rule match starts.
+<li>
+<p><code>location: number</code> is the index (zero-based) at which the rule match starts.
 You might use this to show the location of an expression in an error message.</p>
 <blockquote>
 <p>Note: Many <a href="tokenizers">tokenizers</a> provide line, column, and offset
@@ -371,21 +377,21 @@ would only tell you that it saw the nth <em>token</em> rather than the nth
 <em>character</em> in the string.</p>
 </blockquote>
 </li>
-<li><p><code>reject: Object</code> is a unique object that you can return to signal that this
-rule doesn’t <em>actually</em> match its input.</p>
+<li>
+<p><code>reject: Object</code> is a unique object that you can return to signal that this
+rule doesn&apos;t <em>actually</em> match its input.</p>
 <p>Reject is used in some edge cases. For example, suppose you want sequences of
 letters to match variables, except for the keyword <code>if</code>. In this case, your
 rule may be</p>
-<pre><code class="lang-ne">variable -&gt; [a-z]:+ {%
-    function(d,l, reject) {
-        if (d[0] == &#39;if&#39;) {
-            return reject;
-        } else {
-            return {&#39;name&#39;: d[0]};
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">variable</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[a-z]</span><span class="pl-k">:+</span> <span class="pl-c">{%</span>
+    <span class="pl-k">function</span>(<span class="pl-smi">d</span>,<span class="pl-smi">l</span>, <span class="pl-smi">reject</span>) {
+        <span class="pl-k">if</span> (d[<span class="pl-c1">0</span>] <span class="pl-k">==</span> <span class="pl-s"><span class="pl-pds">&apos;</span>if<span class="pl-pds">&apos;</span></span>) {
+            <span class="pl-k">return</span> reject;
+        } <span class="pl-k">else</span> {
+            <span class="pl-k">return</span> {<span class="pl-s"><span class="pl-pds">&apos;</span>name<span class="pl-pds">&apos;</span></span><span class="pl-k">:</span> d[<span class="pl-c1">0</span>]};
         }
     }
-%}
-</code></pre>
+<span class="pl-c">%}</span></pre></div>
 <blockquote>
 <p>Warning: Grammars using <code>reject</code> are not context-free, and are often much
 slower to parse. So, we encourage you not to use <code>reject</code> unless absolutely
@@ -395,145 +401,158 @@ necessary. You can usually use a tokenizer instead.</p>
 </ul>
 <p>nearley provides two built-in postprocessors for the most common scenarios:</p>
 <ul>
-<li><code>id</code> returns the first element of the <code>data</code> array. This is useful to
-extract the content of a single-element array: <code>foo -&gt; bar {% id %}</code></li>
-<li><code>nuller</code> returns the JavaScript <code>null</code> value. This is useful for whitespace
-rules: <code>space -&gt; &quot; &quot; {% nuller %}</code></li>
+<li>
+<code>id</code> returns the first element of the <code>data</code> array. This is useful to
+extract the content of a single-element array: <code>foo -&gt; bar {% id %}</code>
+</li>
+<li>
+<code>nuller</code> returns the JavaScript <code>null</code> value. This is useful for whitespace
+rules: <code>space -&gt; &quot; &quot; {% nuller %}</code>
+</li>
 </ul>
-<h3 id="more-syntax-tips-and-tricks">More syntax: tips and tricks</h3>
-<h4 id="comments">Comments</h4>
-<p>Comments are marked with ‘#’. Everything from <code>#</code> to the end of a line is
+<h3 id="more-syntax-tips-and-tricks">
+More syntax: tips and tricks</h3>
+<h4>
+<a id="user-content-comments" class="anchor" href="#comments" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Comments</h4>
+<p>Comments are marked with &apos;#&apos;. Everything from <code>#</code> to the end of a line is
 ignored:</p>
-<pre><code class="lang-ne">expression -&gt; number &quot;+&quot; number # sum of two numbers
-</code></pre>
-<h4 id="charsets">Charsets</h4>
-<p>You can use valid RegExp charsets in a rule (unless you’re using a
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">expression</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span> <span class="pl-c"># sum of two numbers</span></pre></div>
+<h4>
+<a id="user-content-charsets" class="anchor" href="#charsets" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Charsets</h4>
+<p>You can use valid RegExp charsets in a rule (unless you&apos;re using a
 <a href="tokenizers">tokenizer</a>):</p>
 <pre><code>not_a_letter -&gt; [^a-zA-Z]
-</code></pre><p>The <code>.</code> character can be used to represent any character.</p>
-<h4 id="case-insensitive-string-literals">Case-insensitive string literals</h4>
+</code></pre>
+<p>The <code>.</code> character can be used to represent any character.</p>
+<h4>
+<a id="user-content-case-insensitive-string-literals" class="anchor" href="#case-insensitive-string-literals" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Case-insensitive string literals</h4>
 <p>You can create case-insensitive string literals by adding an <code>i</code> after the
 string literal:</p>
 <pre><code>cow -&gt; &quot;cow&quot;i # matches CoW, COW, and so on.
-</code></pre><p>Note that if you are using a lexer, your lexer should use the <code>i</code> flag in its
+</code></pre>
+<p>Note that if you are using a lexer, your lexer should use the <code>i</code> flag in its
 regexes instead. That is, if you are using a lexer, you should <em>not</em> use the
 <code>i</code> suffix in nearley.</p>
-<h4 id="ebnf">EBNF</h4>
+<h4>
+<a id="user-content-ebnf" class="anchor" href="#ebnf" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>EBNF</h4>
 <p>nearley supports the <code>*</code>, <code>?</code>, and <code>+</code> operators from
-<a href="https://en.wikipedia.org/wiki/Extended_Backus–Naur_form">EBNF</a> as shown:</p>
-<pre><code class="lang-ne">batman -&gt; &quot;na&quot;:* &quot;batman&quot; # nananana...nanabatman
-</code></pre>
+<a href="https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form" rel="nofollow">EBNF</a> as shown:</p>
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">batman</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;na&quot;</span><span class="pl-k">:*</span> <span class="pl-s">&quot;batman&quot;</span> <span class="pl-c"># nananana...nanabatman</span></pre></div>
 <p>You can also use capture groups with parentheses. Its contents can be anything
 that a rule can have:</p>
-<pre><code class="lang-ne">banana -&gt; &quot;ba&quot; (&quot;na&quot; {% id %} | &quot;NA&quot; {% id %}):+
-</code></pre>
-<h3 id="macros">Macros</h3>
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">banana</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;ba&quot;</span> <span class="pl-k">(</span><span class="pl-s">&quot;na&quot;</span> <span class="pl-c">{%</span> id <span class="pl-c">%}</span> <span class="pl-k">|</span> <span class="pl-s">&quot;NA&quot;</span> <span class="pl-c">{%</span> id <span class="pl-c">%}</span><span class="pl-k">):+</span></pre></div>
+<h3 id="macros">
+Macros</h3>
 <p>Macros allow you to create polymorphic rules:</p>
-<pre><code class="lang-ne"># Matches &quot;&#39;Hello?&#39; &#39;Hello?&#39; &#39;Hello?&#39;&quot;
-matchThree[X] -&gt; $X &quot; &quot; $X &quot; &quot; $X
-inQuotes[X] -&gt; &quot;&#39;&quot; $X &quot;&#39;&quot;
+<div class="highlight highlight-source-ne"><pre><span class="pl-c"># Matches &quot;&apos;Hello?&apos; &apos;Hello?&apos; &apos;Hello?&apos;&quot;</span>
+<span class="pl-en">matchThree</span><span class="pl-v">[X]</span> <span class="pl-k">-&gt;</span> <span class="pl-v">$X</span> <span class="pl-s">&quot; &quot;</span> <span class="pl-v">$X</span> <span class="pl-s">&quot; &quot;</span> <span class="pl-v">$X</span>
+<span class="pl-en">inQuotes</span><span class="pl-v">[X]</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;&apos;&quot;</span> <span class="pl-v">$X</span> <span class="pl-s">&quot;&apos;&quot;</span>
 
-main -&gt; matchThree[inQuotes[&quot;Hello?&quot;]]
-</code></pre>
+<span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-en">matchThree[inQuotes[</span><span class="pl-s">&quot;Hello?&quot;</span><span class="pl-en">]]</span></pre></div>
 <p>Macros are dynamically scoped, which means they see arguments passed to parent
 macros:</p>
-<pre><code class="lang-ne"># Matches &quot;Cows oink.&quot; and &quot;Cows moo!&quot;
-sentence[ANIMAL, PUNCTUATION] -&gt; animalGoes[(&quot;moo&quot; | &quot;oink&quot; | &quot;baa&quot;)] $PUNCTUATION
-animalGoes[SOUND] -&gt; $ANIMAL &quot; &quot; $SOUND # uses $ANIMAL from its caller
+<div class="highlight highlight-source-ne"><pre><span class="pl-c"># Matches &quot;Cows oink.&quot; and &quot;Cows moo!&quot;</span>
+<span class="pl-en">sentence</span><span class="pl-v">[ANIMAL, PUNCTUATION]</span> <span class="pl-k">-&gt;</span> <span class="pl-en">animalGoes[</span><span class="pl-k">(</span><span class="pl-s">&quot;moo&quot;</span> <span class="pl-k">|</span> <span class="pl-s">&quot;oink&quot;</span> <span class="pl-k">|</span> <span class="pl-s">&quot;baa&quot;</span><span class="pl-k">)</span><span class="pl-en">]</span> <span class="pl-v">$PUNCTUATION</span>
+<span class="pl-en">animalGoes</span><span class="pl-v">[SOUND]</span> <span class="pl-k">-&gt;</span> <span class="pl-v">$ANIMAL</span> <span class="pl-s">&quot; &quot;</span> <span class="pl-v">$SOUND</span> <span class="pl-c"># uses $ANIMAL from its caller</span>
 
-main -&gt; sentence[&quot;Cows&quot;, (&quot;.&quot; | &quot;!&quot;)]
-</code></pre>
+<span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-en">sentence[</span><span class="pl-s">&quot;Cows&quot;</span>, <span class="pl-k">(</span><span class="pl-s">&quot;.&quot;</span> <span class="pl-k">|</span> <span class="pl-s">&quot;!&quot;</span><span class="pl-k">)</span><span class="pl-en">]</span></pre></div>
 <p>Macros are expanded at compile time and inserted in places they are used. They
-are not “real” rules. Therefore, macros <em>cannot</em> be recursive (<code>nearleyc</code> will
+are not &quot;real&quot; rules. Therefore, macros <em>cannot</em> be recursive (<code>nearleyc</code> will
 go into an infinite loop trying to expand the macro-loop). They must also be
 defined <em>before</em> they are used.</p>
-<h3 id="additional-js">Additional JS</h3>
+<h3 id="additional-js">
+Additional JS</h3>
 <p>For more intricate postprocessors, or any other functionality you may need, you
 can include chunks of JavaScript code between production rules by surrounding
 it with <code>@{% ... %}</code>:</p>
-<pre><code class="lang-ne">@{%
-const cowSays = require(&quot;./cow.js&quot;);
-%}
+<div class="highlight highlight-source-ne"><pre><span class="pl-c">@{%</span>
+<span class="pl-k">const</span> <span class="pl-c1">cowSays</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>./cow.js<span class="pl-pds">&quot;</span></span>);
+<span class="pl-c">%}</span>
 
-cow -&gt; &quot;moo&quot; {% ([moo]) =&gt; cowSays(moo) %}
-</code></pre>
-<p>Note that it doesn’t matter where you add these; they all get hoisted to the
+<span class="pl-en">cow</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;moo&quot;</span> <span class="pl-c">{%</span> ([<span class="pl-smi">moo</span>]) <span class="pl-k">=&gt;</span> <span class="pl-en">cowSays</span>(moo) <span class="pl-c">%}</span></pre></div>
+<p>Note that it doesn&apos;t matter where you add these; they all get hoisted to the
 top of the generated code.</p>
-<h3 id="importing-other-grammars">Importing other grammars</h3>
+<h3 id="importing-other-grammars">
+Importing other grammars</h3>
 <p>You can include the content of other grammar files:</p>
-<pre><code class="lang-ne">@include &quot;../misc/primitives.ne&quot; # path relative to file being compiled
-sum -&gt; number &quot;+&quot; number # uses &quot;number&quot; from the included file
-</code></pre>
-<p>There are some common nonterminals like “integer” and “double-quoted string”
+<div class="highlight highlight-source-ne"><pre><span class="pl-k">@include</span> <span class="pl-s">&quot;../misc/primitives.ne&quot;</span> <span class="pl-c"># path relative to file being compiled</span>
+<span class="pl-en">sum</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;+&quot;</span> <span class="pl-en">number</span> <span class="pl-c"># uses &quot;number&quot; from the included file</span></pre></div>
+<p>There are some common nonterminals like &quot;integer&quot; and &quot;double-quoted string&quot;
 that ship with nearley to help you prototype grammars efficiently. You can
 include them using the <code>@builtin</code> directive:</p>
-<pre><code class="lang-ne">@builtin &quot;number.ne&quot;
-main -&gt; int:+
-</code></pre>
-<p>(Note that we mean “efficient” in the sense that you can get them set up very
+<div class="highlight highlight-source-ne"><pre><span class="pl-k">@builtin</span> <span class="pl-s">&quot;number.ne&quot;</span>
+<span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-en">int</span><span class="pl-k">:+</span></pre></div>
+<p>(Note that we mean &quot;efficient&quot; in the sense that you can get them set up very
 quickly. The builtins are <em>inefficient</em> in the sense that they make your parser
-slower. For a “real” project, you would want to switch to a lexer and implement
+slower. For a &quot;real&quot; project, you would want to switch to a lexer and implement
 these primitives yourself!)</p>
 <p>See the <a href="https://github.com/kach/nearley/tree/master/builtin"><code>builtin/</code></a> directory on Github for more details. Contributions are
 welcome!</p>
 <p>Note that including a file imports <em>all</em> of the nonterminals defined in it, as
 well as any JS, macros, and configuration options defined there.</p>
-<h3 id="what-s-next-">What’s next?</h3>
-<p>Now that you have a grammar, you’re ready to <a href="parser">learn how to use it to build a
+<h3 id="whats-next">
+What&apos;s next?</h3>
+<p>Now that you have a grammar, you&apos;re ready to <a href="parser">learn how to use it to build a
 parser!</a></p>
-
+</body></html>
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
     href="http://hardmath123.github.io">Hardmath123</a> (<a
     href="http://github.com/Hardmath123">Github</a>). You're welcome to
     leave questions, comments, advice, or ideas as Github issues. And
     feel free to fork nearley with your own experiments!<br/>
-    
+
     <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
     <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
 </div>
 
-<script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>
-document.querySelector('#highlight-js').addEventListener('load', function() {
-    [].slice.apply(document.querySelectorAll('pre code')).forEach(function(b) {
-        hljs.highlightBlock(b)
-    })
-})
-</script>
-
 
 <script>
-window.addEventListener('scroll', onScroll)
-window.addEventListener('resize', onScroll)
+window.addEventListener("scroll", onScroll);
+window.addEventListener("resize", onScroll);
 
-var timeout
+var timeout;
 function onScroll(e) {
-    if (timeout) clearTimeout(timeout)
-    timeout = setTimeout(scrollEnd, 50)
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(scrollEnd, 50);
 }
 
 function scrollEnd() {
-  var headings = document.querySelectorAll('h3')
-  var offset = 60
-  for (var i=headings.length; i--; ) {
-    var h3 = headings[i]
+  var headings = document.querySelectorAll("h3");
+  var offset = 60;
+  for (var i = headings.length; i--; ) {
+    var h3 = headings[i];
     if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector('.page-heading-active')
-      if (cur) cur.className = 'page-heading'
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
-      return
+      var cur = document.querySelector(".page-heading-active");
+      if (cur) cur.className = "page-heading";
+      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
+        "page-heading page-heading-active";
+      return;
     }
   }
 }
 </script>
 
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-46120535-5', 'auto');
-ga('send', 'pageview');
+(function(i, s, o, g, r, a, m) {
+  i["GoogleAnalyticsObject"] = r;
+  (i[r] =
+    i[r] ||
+    function() {
+      (i[r].q = i[r].q || []).push(arguments);
+    }),
+    (i[r].l = 1 * new Date());
+  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+  a.async = 1;
+  a.src = g;
+  m.parentNode.insertBefore(a, m);
+})(
+  window,
+  document,
+  "script",
+  "https://www.google-analytics.com/analytics.js",
+  "ga"
+);
+ga("create", "UA-46120535-5", "auto");
+ga("send", "pageview");
 </script>
-

--- a/docs/grammar.html
+++ b/docs/grammar.html
@@ -241,8 +241,6 @@ nav ul a {
     }
 }
 
-/* highlight.js */
-
 .highlight pre {
   display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
 }
@@ -534,25 +532,5 @@ function scrollEnd() {
 </script>
 
 <script>
-(function(i, s, o, g, r, a, m) {
-  i["GoogleAnalyticsObject"] = r;
-  (i[r] =
-    i[r] ||
-    function() {
-      (i[r].q = i[r].q || []).push(arguments);
-    }),
-    (i[r].l = 1 * new Date());
-  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-  a.async = 1;
-  a.src = g;
-  m.parentNode.insertBefore(a, m);
-})(
-  window,
-  document,
-  "script",
-  "https://www.google-analytics.com/analytics.js",
-  "ga"
-);
-ga("create", "UA-46120535-5", "auto");
-ga("send", "pageview");
+(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
 </script>

--- a/docs/grammar.html
+++ b/docs/grammar.html
@@ -579,12 +579,12 @@ parser!</a></p>
     </script>
 
     <script>
-      (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-      ga('create', 'UA-46120535-5', 'auto');
-      ga('send', 'pageview');
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-46120535-5', 'auto');
+ga('send', 'pageview');
     </script>
+  </div>
+</body>

--- a/docs/how-to-grammar-good.html
+++ b/docs/how-to-grammar-good.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <title>How to grammar good - nearley.js - JS Parsing Toolkit</title>
-<meta charset="utf-8"/>
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
-@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
+  @import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -145,11 +145,23 @@ code {
 
 pre code, .highlight pre {
     border-radius: 0.5em;
-    padding: 0.5em;
+    margin: 5px;
+    padding: 10px;
     display: block;
     overflow: auto;
 }
 
+.highlight pre {
+    padding: 0;
+    margin: 0;
+    display: block;
+    overflow-x: auto;
+}
+
+pre > code > pre > code {
+    padding: 0;
+    margin: 0;
+}
 
 ol {
     counter-reset: tutorial-counter;
@@ -206,7 +218,7 @@ nav ul a {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 0.25em 0.5em; */
+    padding: 0.25em 0.5em;
 }
 .page {
     display: block;
@@ -241,216 +253,263 @@ nav ul a {
     }
 }
 
-.highlight pre {
-  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+code pre {
+    margin: 0;
 }
-
 </style>
 
-<body class="docs-page">
+<body class="docs-page" >
 
-<a href="https://github.com/kach/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-<nav id="nav">
-    <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">2.12.1</span></a></h1>
+  <a href="https://github.com/kach/nearley" class="github-corner">
+    <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg>
+  </a>
+  <style>
+    .github-corner:hover .octo-arm {
+      animation: octocat-wave 560ms ease-in-out
+    }
+
+    @keyframes octocat-wave {
+      0%,
+      100% {
+        transform: rotate(0)
+      }
+      20%,
+      60% {
+        transform: rotate(-25deg)
+      }
+      40%,
+      80% {
+        transform: rotate(10deg)
+      }
+    }
+
+    @media (max-width:500px) {
+      .github-corner:hover .octo-arm {
+        animation: none
+      }
+      .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out
+      }
+    }
+  </style>
+  <nav id="nav">
+    <h1>
+      <a href="/">nearley
+        <span style="color: #559;">.js</span>
+        <span id="version">2.12.1</span>
+      </a>
+    </h1>
     <ul>
-        <li class="page"><a href="/docs/index">Home</a>
-        <li class="page"><a href="/docs/getting-started">Getting started</a>
-        <li class="page"><a href="/docs/grammar">Writing a parser</a>
-        <li class="page"><a href="/docs/parser">Using a parser</a>
-        <li class="page"><a href="/docs/tokenizers">Tokenizers</a>
-        <li class="page"><a href="/docs/tooling">Tooling</a>
-        <li class="page">
-            <a href="#" class="page-title-active">How to grammar good</a>
-            <ul>
-                <li class="page-heading"><a href="#structure">
-Structure</a></li>
-                <li class="page-heading"><a href="#nonterminal-names">
-Nonterminal names</a></li>
-                <li class="page-heading"><a href="#dont-roll-your-own-unroller">
-Don&#x27;t roll your own unroller</a></li>
-                <li class="page-heading"><a href="#postprocess-or-dispose">
-Postprocess or dispose</a></li>
-                <li class="page-heading"><a href="#remember-charclasses-arent-regexes">
-Remember, charclasses aren&#x27;t regexes</a></li>
-                <li class="page-heading"><a href="#debug-with-nearley-test">
-Debug with nearley-test</a></li>
-                <li class="page-heading"><a href="#dont-shy-away-from-left-recursion">
-Don&#x27;t shy away from left recursion</a></li>
-                <li class="page-heading"><a href="#do-shy-away-from-left-recursion">
-Do shy away from left recursion</a></li>
-                <li class="page-heading"><a href="#operator-precedence-is-not-black-magic">
-Operator precedence is not black magic</a></li>
-                <li class="page-heading"><a href="#comment-your-grammars">
-Comment your grammars</a></li>
-                <li class="page-heading"><a href="#use-whitespace-prettily">
-Use whitespace prettily</a></li>
-                <li class="page-heading"><a href="#parsing-an-established-language-cheat">
-Parsing an established language? Cheat!</a></li>
-            </ul>
+               <li class="page">
+          <a href="/docs/index">Home</a>
+                    <li class="page">
+          <a href="/docs/getting-started">Getting started</a>
+                    <li class="page">
+          <a href="/docs/grammar">Writing a parser</a>
+                    <li class="page">
+          <a href="/docs/parser">Using a parser</a>
+                    <li class="page">
+          <a href="/docs/tokenizers">Tokenizers</a>
+                    <li class="page">
+          <a href="/docs/tooling">Tooling</a>
+            
+      <li class="page">
+        <a href="#" class="page-title-active">How to grammar good</a>
+        <ul>
+          <li class="page-heading">
+            <a href="#structure">Structure</a>
+          <li class="page-heading">
+            <a href="#don-t-roll-your-own-unroller">Don’t roll your own unroller</a>
+          <li class="page-heading">
+            <a href="#postprocess-or-dispose">Postprocess or dispose</a>
+          <li class="page-heading">
+            <a href="#remember-charclasses-aren-t-regexes">Remember, charclasses aren’t regexes</a>
+          <li class="page-heading">
+            <a href="#debug-with-nearley-test">Debug with nearley-test</a>
+          <li class="page-heading">
+            <a href="#don-t-shy-away-from-left-recursion">Don’t shy away from left recursion</a>
+          <li class="page-heading">
+            <a href="#comment-your-grammars">Comment your grammars</a>
+          <li class="page-heading">
+            <a href="#use-whitespace-prettily">Use whitespace prettily</a>
+          <li class="page-heading">
+            <a href="#parsing-an-established-language-cheat-">Parsing an established language? Cheat!</a>
+        </ul>
         </li>
-        <li class="page"><a href="/docs/using-in-frontend">Compiling in browsers</a>
-        <li class="page"><a href="/docs/glossary">Glossary</a>
+          <li class="page">
+          <a href="/docs/using-in-frontend">Compiling in browsers</a>
+                    <li class="page">
+          <a href="/docs/glossary">Glossary</a>
+           
     </ul>
-</nav>
+  </nav>
 
-<div id="main" class="center">
+  <div id="main" class="center">
 
-<h2>How to grammar good</h2>
-<html><head></head><body><p>A lot of people have pointed out to me that writing grammars for
-<a href="http://hardmath123.github.io/nearley/" rel="nofollow">nearley</a> is <em>hard</em>. The thing is,
-writing grammars is, in general, very hard. It doesn&apos;t help that certain
+    <h2>How to grammar good</h2>
+    <p>A lot of people have pointed out to me that writing grammars for
+<a href="http://hardmath123.github.io/nearley/">nearley</a> is <em>hard</em>. The thing is,
+writing grammars is, in general, very hard. It doesn’t help that certain
 grammar-related problems are provably undecidable.</p>
 <p>As with all of programming, grammar-writing is guided by instinct and pattern
 recognition (on the part of the human, in this case!). This guide is meant to
 walk through some common idioms, ideas, anti-patterns and pitfalls, and
 hopefully make you a confident grammarian. Treat it more as a styleguide than a
 tutorial.</p>
-<p>It might be worth reading <a href="http://hardmath123.github.io/earley.html" rel="nofollow">Better Earley than
+<p>It might be worth reading <a href="http://hardmath123.github.io/earley.html">Better Earley than
 Never</a> first, to understand the
-algorithm and some basic concepts. From here on out, I&apos;m assuming you know what
+algorithm and some basic concepts. From here on out, I’m assuming you know what
 <em>regular expression</em>, <em>Backus Naur Form</em>, <em>context free grammar</em>, <em>terminal</em>,
 <em>nonterminal</em>, and <em>ambiguous grammar</em> mean. You should know nearley syntax
 well enough to understand what something like</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">int</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[0-9]</span>        <span class="pl-c">{%</span> id <span class="pl-c">%}</span>
-    <span class="pl-k">|</span> <span class="pl-en">int</span> <span class="pl-s">[0-9]</span>     <span class="pl-c">{%</span> <span class="pl-k">function</span>(<span class="pl-smi">d</span>) {<span class="pl-k">return</span> d[<span class="pl-c1">0</span>] <span class="pl-k">+</span> d[<span class="pl-c1">1</span>]} <span class="pl-c">%}</span></pre></div>
-<p>means (though I like to pride myself on the readability of nearley grammar...).</p>
-<h3 id="structure">
-Structure</h3>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">int</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[0-9]</span>        <span class="pl-c">{%</span> id <span class="pl-c">%}</span>
+    <span class="pl-k">|</span> <span class="pl-en">int</span> <span class="pl-s">[0-9]</span>     <span class="pl-c">{%</span> <span class="pl-k">function</span>(<span class="pl-smi">d</span>) {<span class="pl-k">return</span> d[<span class="pl-c1">0</span>] <span class="pl-k">+</span> d[<span class="pl-c1">1</span>]} <span class="pl-c">%}</span></pre></div></code></pre>
+<p>means (though I like to pride myself on the readability of nearley grammar…).</p>
+<h3 id="structure">Structure</h3>
 <p>Your grammar should be structured from the top down. The first few rules in a
 file should describe a general outline, and tiny details (terminals for
-whitespace, literals etc.) should be at the bottom. For example, if you&apos;re
+whitespace, literals etc.) should be at the bottom. For example, if you’re
 writing a parser for Scheme, you would start with</p>
-<pre><code>Sourcefile -&gt; (S-expression | Comment):*
-</code></pre>
-<p>and then fill out what <code>s-expression</code> and <code>comment</code> mean. Most of the time,
-rules defined higher in the file reference rules defined lower down, and rules
-defined near the bottom rarely ever reference rules near the top.</p>
-<h3 id="nonterminal-names">
-Nonterminal names</h3>
-<p>Give your nonterminals useful names--mostly nouns that describe the string it
-will match. By convention, we use <code>_</code> for optional whitespace and <code>__</code> for
-mandatory whitespace: it makes it easy to write rules like</p>
-<pre><code>&quot;(&quot; _ expression _ &quot;)&quot;
-</code></pre>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">Sourcefile</span> <span class="pl-k">-&gt;</span> <span class="pl-k">(</span><span class="pl-en">S</span>-<span class="pl-en">expression</span> <span class="pl-k">|</span> <span class="pl-en">Comment</span><span class="pl-k">):*</span>
+```<span class="pl-en">ne</span>
+
+<span class="pl-en">and</span> <span class="pl-en">then</span> <span class="pl-en">fill</span> <span class="pl-en">out</span> <span class="pl-en">what</span> `<span class="pl-en">s</span>-<span class="pl-en">expression</span>` <span class="pl-en">and</span> `<span class="pl-en">comment</span>` <span class="pl-en">mean</span>. <span class="pl-en">Most</span> <span class="pl-en">of</span> <span class="pl-en">the</span> <span class="pl-en">time</span>,
+<span class="pl-en">rules</span> <span class="pl-en">defined</span> <span class="pl-en">higher</span> <span class="pl-en">in</span> <span class="pl-en">the</span> <span class="pl-en">file</span> <span class="pl-en">reference</span> <span class="pl-en">rules</span> <span class="pl-en">defined</span> <span class="pl-en">lower</span> <span class="pl-en">down</span>, <span class="pl-en">and</span> <span class="pl-en">rules</span>
+<span class="pl-en">defined</span> <span class="pl-en">near</span> <span class="pl-en">the</span> <span class="pl-en">bottom</span> <span class="pl-en">rarely</span> <span class="pl-en">ever</span> <span class="pl-en">reference</span> <span class="pl-en">rules</span> <span class="pl-en">near</span> <span class="pl-en">the</span> <span class="pl-en">top</span>.
+
+<span class="pl-c">### Nonterminal names</span>
+
+<span class="pl-en">Give</span> <span class="pl-en">your</span> <span class="pl-en">nonterminals</span> <span class="pl-en">useful</span> <span class="pl-en">names</span>--<span class="pl-en">mostly</span> <span class="pl-en">nouns</span> <span class="pl-en">that</span> <span class="pl-en">describe</span> <span class="pl-en">the</span> <span class="pl-en">string</span> <span class="pl-en">it</span>
+<span class="pl-en">will</span> <span class="pl-en">match</span>. <span class="pl-en">By</span> <span class="pl-en">convention</span>, <span class="pl-en">we</span> <span class="pl-en">use</span> `<span class="pl-en">_</span>` <span class="pl-en">for</span> <span class="pl-en">optional</span> <span class="pl-en">whitespace</span> <span class="pl-en">and</span> `<span class="pl-en">__</span>` <span class="pl-en">for</span>
+<span class="pl-en">mandatory</span> <span class="pl-en">whitespace</span>: <span class="pl-en">it</span> <span class="pl-en">makes</span> <span class="pl-en">it</span> <span class="pl-en">easy</span> <span class="pl-en">to</span> <span class="pl-en">write</span> <span class="pl-en">rules</span> <span class="pl-en">like</span>
+
+```<span class="pl-en">ne</span>
+<span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">expression</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span></pre></div></code></pre>
 <p>You can explicitly mark a nonterminal as optional or repetitive by postfixing
-its name with <code>?</code> and <code>+</code> (respectively)--as in <code>statementlist+</code> or <code>comment?</code>.
-Note that this has no semantic value: use nearley&apos;s EBNF modifiers (<code>:*</code>, <code>:+</code>,
+its name with <code>?</code> and <code>+</code> (respectively)–as in <code>statementlist+</code> or <code>comment?</code>.
+Note that this has no semantic value: use nearley’s EBNF modifiers (<code>:*</code>, <code>:+</code>,
 <code>:?</code>) for that.</p>
-<h3 id="dont-roll-your-own-unroller">
-Don&apos;t roll your own unroller</h3>
-<p>If you want to match one or more of a nonterminal, use an EBNF modifier. It&apos;s
+<h3 id="don-t-roll-your-own-unroller">Don’t roll your own unroller</h3>
+<p>If you want to match one or more of a nonterminal, use an EBNF modifier. It’s
 semantically legible, contextually appropriate and (most importantly) easy.
-It&apos;s very easy to mess up and create an exponentially ambiguous monstrosity
+It’s very easy to mess up and create an exponentially ambiguous monstrosity
 such as</p>
-<pre><code>lotsofletters -&gt; &quot;a&quot; | lotsofletters lotsofletters
-</code></pre>
-<h3 id="postprocess-or-dispose">
-Postprocess or dispose</h3>
-<p>nearley saves a nested array structure by default, but most of the time that&apos;s
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">lotsofletters</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;a&quot;</span> <span class="pl-k">|</span> <span class="pl-en">lotsofletters</span> <span class="pl-en">lotsofletters</span></pre></div></code></pre>
+<h3 id="postprocess-or-dispose">Postprocess or dispose</h3>
+<p>nearley saves a nested array structure by default, but most of the time that’s
 not what you want. For things like whitespace, you want to throw away all that
 useless information for memory efficiency, so use a postprocessor that just
 returns <code>null</code>. For syntactic sugar and stuff, construct object literals so
 that the code that processes your AST is relatively independent of your
 grammar. Constructing object literals also lets you discard junk (parens,
 etc.).</p>
-<h3 id="remember-charclasses-arent-regexes">
-Remember, charclasses aren&apos;t regexes</h3>
+<h3 id="remember-charclasses-aren-t-regexes">Remember, charclasses aren’t regexes</h3>
 <p>The <code>[a-z]</code> syntax only allows you to use regex-style character classes, not
 actual regular expressions. Nearley fundamentally does not support regexes as
-terminals. Use EBNF modifiers instead--they do what you want.</p>
-<h3 id="debug-with-nearley-test">
-Debug with nearley-test</h3>
+terminals. Use EBNF modifiers instead–they do what you want.</p>
+<h3 id="debug-with-nearley-test">Debug with nearley-test</h3>
 <p>Use the <code>nearley-test</code> script (installs alongside <code>nearleyc</code>) to debug your
 grammars. It lets you inspect the parse tables, and see all the parsings, or
 the point of failure. This is invaluable when you have a subtle ambiguity
 issue.</p>
-<h3 id="dont-shy-away-from-left-recursion">
-Don&apos;t shy away from left recursion</h3>
+<h3 id="don-t-shy-away-from-left-recursion">Don’t shy away from left recursion</h3>
 <p>You were a good little student and you paid attention to your professors when
 they told you never to write grammars like:</p>
-<pre><code>a -&gt; a &quot;something&quot;
-</code></pre>
-<p>because a na&#xEF;ve recursive-descent parser would bork in an infinite loop.
-Nearley, of course, is much better, so you don&apos;t have to worry about that. If
-you&apos;re paranoid about efficiency, you should actually prefer left recursion
-over right recursion (<code>a -&gt; &quot;something&quot; a</code>) because it&apos;s very slightly faster.
-In any case, that&apos;s how you deal with left or right associativity for binary
-operators.</p>
-<h3 id="do-shy-away-from-left-recursion">
-Do shy away from left recursion</h3>
-<p>...if you&apos;re using it where the EBNF <code>:*</code> or <code>:+</code> makes more sense!</p>
-<h3 id="operator-precedence-is-not-black-magic">
-Operator precedence is not black magic</h3>
-<p>Here&apos;s how you do it: you start with your lowest-precedence operator and work
-your way up to your highest precedence ones. Each operator gets its own
-nonterminal:</p>
-<pre><code>math -&gt; sum
-sum -&gt; sum (&quot;+&quot;|&quot;-&quot;) product | product
-product -&gt; product (&quot;*&quot;|&quot;/&quot;) exp | exp
-exp -&gt; number &quot;^&quot; exp | number # this is right associative!
-</code></pre>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">a</span> <span class="pl-k">-&gt;</span> <span class="pl-en">a</span> <span class="pl-s">&quot;something&quot;</span>
+```<span class="pl-en">ne</span>
+
+<span class="pl-en">because</span> <span class="pl-en">a</span> <span class="pl-en">na</span>&#xEF;<span class="pl-en">ve</span> <span class="pl-en">recursive</span>-<span class="pl-en">descent</span> <span class="pl-en">parser</span> <span class="pl-en">would</span> <span class="pl-en">bork</span> <span class="pl-en">in</span> <span class="pl-en">an</span> <span class="pl-en">infinite</span> <span class="pl-en">loop</span>.
+<span class="pl-en">Nearley</span>, <span class="pl-en">of</span> <span class="pl-en">course</span>, <span class="pl-en">is</span> <span class="pl-en">much</span> <span class="pl-en">better</span>, <span class="pl-en">so</span> <span class="pl-en">you</span> <span class="pl-en">don</span>&apos;<span class="pl-en">t</span> <span class="pl-en">have</span> <span class="pl-en">to</span> <span class="pl-en">worry</span> <span class="pl-en">about</span> <span class="pl-en">that</span>. <span class="pl-en">If</span>
+<span class="pl-en">you</span>&apos;<span class="pl-en">re</span> <span class="pl-en">paranoid</span> <span class="pl-en">about</span> <span class="pl-en">efficiency</span>, <span class="pl-en">you</span> <span class="pl-en">should</span> <span class="pl-en">actually</span> <span class="pl-en">prefer</span> <span class="pl-en">left</span> <span class="pl-en">recursion</span>
+<span class="pl-en">over</span> <span class="pl-en">right</span> <span class="pl-en">recursion</span> <span class="pl-k">(</span>`<span class="pl-en">a</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;something&quot;</span> <span class="pl-en">a</span>`<span class="pl-k">)</span> <span class="pl-en">because</span> <span class="pl-en">it</span>&apos;<span class="pl-en">s</span> <span class="pl-en">very</span> <span class="pl-en">slightly</span> <span class="pl-en">faster</span>.
+<span class="pl-en">In</span> <span class="pl-en">any</span> <span class="pl-en">case</span>, <span class="pl-en">that</span>&apos;<span class="pl-en">s</span> <span class="pl-en">how</span> <span class="pl-en">you</span> <span class="pl-en">deal</span> <span class="pl-en">with</span> <span class="pl-en">left</span> <span class="pl-en">or</span> <span class="pl-en">right</span> <span class="pl-en">associativity</span> <span class="pl-en">for</span> <span class="pl-en">binary</span>
+<span class="pl-en">operators</span>.
+
+<span class="pl-c">### Do shy away from left recursion</span>
+
+...<span class="pl-en">if</span> <span class="pl-en">you</span>&apos;<span class="pl-en">re</span> <span class="pl-en">using</span> <span class="pl-en">it</span> <span class="pl-en">where</span> <span class="pl-en">the</span> <span class="pl-en">EBNF</span> `<span class="pl-k">:*</span>` <span class="pl-en">or</span> `<span class="pl-k">:+</span>` <span class="pl-en">makes</span> <span class="pl-en">more</span> <span class="pl-en">sense</span>!
+
+<span class="pl-c">### Operator precedence is not black magic</span>
+
+<span class="pl-en">Here</span>&apos;<span class="pl-en">s</span> <span class="pl-en">how</span> <span class="pl-en">you</span> <span class="pl-en">do</span> <span class="pl-en">it</span>: <span class="pl-en">you</span> <span class="pl-en">start</span> <span class="pl-en">with</span> <span class="pl-en">your</span> <span class="pl-en">lowest</span>-<span class="pl-en">precedence</span> <span class="pl-en">operator</span> <span class="pl-en">and</span> <span class="pl-en">work</span>
+<span class="pl-en">your</span> <span class="pl-en">way</span> <span class="pl-en">up</span> <span class="pl-en">to</span> <span class="pl-en">your</span> <span class="pl-en">highest</span> <span class="pl-en">precedence</span> <span class="pl-en">ones</span>. <span class="pl-en">Each</span> <span class="pl-en">operator</span> <span class="pl-en">gets</span> <span class="pl-en">its</span> <span class="pl-en">own</span>
+<span class="pl-en">nonterminal</span>:
+
+```<span class="pl-en">ne</span>
+<span class="pl-en">math</span> <span class="pl-k">-&gt;</span> <span class="pl-en">sum</span>
+<span class="pl-en">sum</span> <span class="pl-k">-&gt;</span> <span class="pl-en">sum</span> <span class="pl-k">(</span><span class="pl-s">&quot;+&quot;</span><span class="pl-k">|</span><span class="pl-s">&quot;-&quot;</span><span class="pl-k">)</span> <span class="pl-en">product</span> <span class="pl-k">|</span> <span class="pl-en">product</span>
+<span class="pl-en">product</span> <span class="pl-k">-&gt;</span> <span class="pl-en">product</span> <span class="pl-k">(</span><span class="pl-s">&quot;*&quot;</span><span class="pl-k">|</span><span class="pl-s">&quot;/&quot;</span><span class="pl-k">)</span> <span class="pl-en">exp</span> <span class="pl-k">|</span> <span class="pl-en">exp</span>
+<span class="pl-en">exp</span> <span class="pl-k">-&gt;</span> <span class="pl-en">number</span> <span class="pl-s">&quot;^&quot;</span> <span class="pl-en">exp</span> <span class="pl-k">|</span> <span class="pl-en">number</span> <span class="pl-c"># this is right associative!</span></pre></div></code></pre>
 <p>It should be pretty clear how this works, and how to extend it to different
 types of operators. The main thing is to be careful with your associativity
-direction. Be careful not to write <code>op -&gt; op &quot;$&quot; op</code>, because that&apos;s ambiguous.</p>
+direction. Be careful not to write <code>op -&gt; op &quot;$&quot; op</code>, because that’s ambiguous.</p>
 <p>Introducing non-conflicting unary negation (<code>&quot;5 * -5&quot;</code>) is left as a trivial
 exercise for the enterprising reader.</p>
-<h3 id="comment-your-grammars">
-Comment your grammars</h3>
-<p>It&apos;s very easy to come back to a grammar a week later and have no idea what
-it&apos;s doing. Leave comments that explain precisely what each nonterminal
+<h3 id="comment-your-grammars">Comment your grammars</h3>
+<p>It’s very easy to come back to a grammar a week later and have no idea what
+it’s doing. Leave comments that explain precisely what each nonterminal
 matches, since a clear description will help you debug things in the future.</p>
-<h3 id="use-whitespace-prettily">
-Use whitespace prettily</h3>
+<h3 id="use-whitespace-prettily">Use whitespace prettily</h3>
 <p>Align your <code>-&gt;</code>s and your <code>|</code>s and your <code>{% ... %}</code>s. Future retinas will thank
 you.</p>
-<h3 id="parsing-an-established-language-cheat">
-Parsing an established language? Cheat!</h3>
+<h3 id="parsing-an-established-language-cheat-">Parsing an established language? Cheat!</h3>
 <p>Almost all standards publish syntax guides with an accompanying diagram in
-(E)BNF. It&apos;s worth it to Google around for this. With just a bit of common
+(E)BNF. It’s worth it to Google around for this. With just a bit of common
 sense, you should be able to transliterate it to a <code>.ne</code> file.</p>
 <hr>
 <p>Again, grammar-writing is largely about instinct and experience. The more you
-write, the more you&apos;ll understand how it goes, and the faster you&apos;ll be able to
+write, the more you’ll understand how it goes, and the faster you’ll be able to
 prototype and design.</p>
-</body></html>
-
-    <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
-    href="http://hardmath123.github.io">Hardmath123</a> (<a
-    href="http://github.com/Hardmath123">Github</a>). You're welcome to
-    leave questions, comments, advice, or ideas as Github issues. And
-    feel free to fork nearley with your own experiments!<br/>
-
-    <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
-    <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
-</div>
 
 
-<script>
-window.addEventListener("scroll", onScroll);
-window.addEventListener("resize", onScroll);
+    <div id="footer">
+      <p>nearley is MIT-licensed. It's maintained by
+        <a href="http://hardmath123.github.io">Hardmath123</a> (
+        <a href="http://github.com/Hardmath123">Github</a>). You're welcome to leave questions, comments, advice, or ideas as Github issues. And feel free to fork
+        nearley with your own experiments!
+        <br/>
 
-var timeout;
-function onScroll(e) {
-  if (timeout) clearTimeout(timeout);
-  timeout = setTimeout(scrollEnd, 50);
-}
+        <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
+          <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo" />
+        </a>
+    </div>
 
-function scrollEnd() {
-  var headings = document.querySelectorAll("h3");
-  var offset = 60;
-  for (var i = headings.length; i--; ) {
-    var h3 = headings[i];
-    if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector(".page-heading-active");
-      if (cur) cur.className = "page-heading";
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
-        "page-heading page-heading-active";
-      return;
-    }
-  }
-}
-</script>
+    <script>
+      window.addEventListener('scroll', onScroll)
+      window.addEventListener('resize', onScroll)
+      var timeout
+      function onScroll(e) {
+        if (timeout) clearTimeout(timeout)
+        timeout = setTimeout(scrollEnd, 50)
+      }
+      function scrollEnd() {
+        var headings = document.querySelectorAll('h3')
+        var offset = 60
+        for (var i = headings.length; i--;) {
+          var h3 = headings[i]
+          if (h3.offsetTop < window.scrollY + offset) {
+            var cur = document.querySelector('.page-heading-active')
+            if (cur) cur.className = 'page-heading'
+            document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
+            return
+          }
+        }
+      }
+    </script>
 
-<script>
-(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
-</script>
+    <script>
+      (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-46120535-5', 'auto');
+      ga('send', 'pageview');
+    </script>

--- a/docs/how-to-grammar-good.html
+++ b/docs/how-to-grammar-good.html
@@ -4,6 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
+@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -142,7 +143,7 @@ code {
     background-color: #eee;
 }
 
-pre code {
+pre code, .highlight pre {
     border-radius: 0.5em;
     padding: 0.5em;
     display: block;
@@ -242,8 +243,9 @@ nav ul a {
 
 /* highlight.js */
 
-.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
-
+.highlight pre {
+  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+}
 
 </style>
 
@@ -262,18 +264,30 @@ nav ul a {
         <li class="page">
             <a href="#" class="page-title-active">How to grammar good</a>
             <ul>
-                <li class="page-heading"><a href="#structure">Structure</a>
-                <li class="page-heading"><a href="#nonterminal-names">Nonterminal names</a>
-                <li class="page-heading"><a href="#don-t-roll-your-own-unroller">Don’t roll your own unroller</a>
-                <li class="page-heading"><a href="#postprocess-or-dispose">Postprocess or dispose</a>
-                <li class="page-heading"><a href="#remember-charclasses-aren-t-regexes">Remember, charclasses aren’t regexes</a>
-                <li class="page-heading"><a href="#debug-with-nearley-test">Debug with nearley-test</a>
-                <li class="page-heading"><a href="#don-t-shy-away-from-left-recursion">Don’t shy away from left recursion</a>
-                <li class="page-heading"><a href="#do-shy-away-from-left-recursion">Do shy away from left recursion</a>
-                <li class="page-heading"><a href="#operator-precedence-is-not-black-magic">Operator precedence is not black magic</a>
-                <li class="page-heading"><a href="#comment-your-grammars">Comment your grammars</a>
-                <li class="page-heading"><a href="#use-whitespace-prettily">Use whitespace prettily</a>
-                <li class="page-heading"><a href="#parsing-an-established-language-cheat-">Parsing an established language? Cheat!</a>
+                <li class="page-heading"><a href="#structure">
+Structure</a></li>
+                <li class="page-heading"><a href="#nonterminal-names">
+Nonterminal names</a></li>
+                <li class="page-heading"><a href="#dont-roll-your-own-unroller">
+Don&#x27;t roll your own unroller</a></li>
+                <li class="page-heading"><a href="#postprocess-or-dispose">
+Postprocess or dispose</a></li>
+                <li class="page-heading"><a href="#remember-charclasses-arent-regexes">
+Remember, charclasses aren&#x27;t regexes</a></li>
+                <li class="page-heading"><a href="#debug-with-nearley-test">
+Debug with nearley-test</a></li>
+                <li class="page-heading"><a href="#dont-shy-away-from-left-recursion">
+Don&#x27;t shy away from left recursion</a></li>
+                <li class="page-heading"><a href="#do-shy-away-from-left-recursion">
+Do shy away from left recursion</a></li>
+                <li class="page-heading"><a href="#operator-precedence-is-not-black-magic">
+Operator precedence is not black magic</a></li>
+                <li class="page-heading"><a href="#comment-your-grammars">
+Comment your grammars</a></li>
+                <li class="page-heading"><a href="#use-whitespace-prettily">
+Use whitespace prettily</a></li>
+                <li class="page-heading"><a href="#parsing-an-established-language-cheat">
+Parsing an established language? Cheat!</a></li>
             </ul>
         </li>
         <li class="page"><a href="/docs/using-in-frontend">Compiling in browsers</a>
@@ -284,159 +298,181 @@ nav ul a {
 <div id="main" class="center">
 
 <h2>How to grammar good</h2>
-<p>A lot of people have pointed out to me that writing grammars for
-<a href="http://hardmath123.github.io/nearley/">nearley</a> is <em>hard</em>. The thing is,
-writing grammars is, in general, very hard. It doesn’t help that certain
+<html><head></head><body><p>A lot of people have pointed out to me that writing grammars for
+<a href="http://hardmath123.github.io/nearley/" rel="nofollow">nearley</a> is <em>hard</em>. The thing is,
+writing grammars is, in general, very hard. It doesn&apos;t help that certain
 grammar-related problems are provably undecidable.</p>
 <p>As with all of programming, grammar-writing is guided by instinct and pattern
 recognition (on the part of the human, in this case!). This guide is meant to
 walk through some common idioms, ideas, anti-patterns and pitfalls, and
 hopefully make you a confident grammarian. Treat it more as a styleguide than a
 tutorial.</p>
-<p>It might be worth reading <a href="http://hardmath123.github.io/earley.html">Better Earley than
+<p>It might be worth reading <a href="http://hardmath123.github.io/earley.html" rel="nofollow">Better Earley than
 Never</a> first, to understand the
-algorithm and some basic concepts. From here on out, I’m assuming you know what
+algorithm and some basic concepts. From here on out, I&apos;m assuming you know what
 <em>regular expression</em>, <em>Backus Naur Form</em>, <em>context free grammar</em>, <em>terminal</em>,
 <em>nonterminal</em>, and <em>ambiguous grammar</em> mean. You should know nearley syntax
 well enough to understand what something like</p>
-<pre><code class="lang-ne">int -&gt; [0-9]        {% id %}
-    | int [0-9]     {% function(d) {return d[0] + d[1]} %}
-</code></pre>
-<p>means (though I like to pride myself on the readability of nearley grammar…).</p>
-<h3 id="structure">Structure</h3>
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">int</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[0-9]</span>        <span class="pl-c">{%</span> id <span class="pl-c">%}</span>
+    <span class="pl-k">|</span> <span class="pl-en">int</span> <span class="pl-s">[0-9]</span>     <span class="pl-c">{%</span> <span class="pl-k">function</span>(<span class="pl-smi">d</span>) {<span class="pl-k">return</span> d[<span class="pl-c1">0</span>] <span class="pl-k">+</span> d[<span class="pl-c1">1</span>]} <span class="pl-c">%}</span></pre></div>
+<p>means (though I like to pride myself on the readability of nearley grammar...).</p>
+<h3 id="structure">
+Structure</h3>
 <p>Your grammar should be structured from the top down. The first few rules in a
 file should describe a general outline, and tiny details (terminals for
-whitespace, literals etc.) should be at the bottom. For example, if you’re
+whitespace, literals etc.) should be at the bottom. For example, if you&apos;re
 writing a parser for Scheme, you would start with</p>
 <pre><code>Sourcefile -&gt; (S-expression | Comment):*
-</code></pre><p>and then fill out what <code>s-expression</code> and <code>comment</code> mean. Most of the time,
+</code></pre>
+<p>and then fill out what <code>s-expression</code> and <code>comment</code> mean. Most of the time,
 rules defined higher in the file reference rules defined lower down, and rules
 defined near the bottom rarely ever reference rules near the top.</p>
-<h3 id="nonterminal-names">Nonterminal names</h3>
-<p>Give your nonterminals useful names–mostly nouns that describe the string it
+<h3 id="nonterminal-names">
+Nonterminal names</h3>
+<p>Give your nonterminals useful names--mostly nouns that describe the string it
 will match. By convention, we use <code>_</code> for optional whitespace and <code>__</code> for
 mandatory whitespace: it makes it easy to write rules like</p>
 <pre><code>&quot;(&quot; _ expression _ &quot;)&quot;
-</code></pre><p>You can explicitly mark a nonterminal as optional or repetitive by postfixing
-its name with <code>?</code> and <code>+</code> (respectively)–as in <code>statementlist+</code> or <code>comment?</code>.
-Note that this has no semantic value: use nearley’s EBNF modifiers (<code>:*</code>, <code>:+</code>,
+</code></pre>
+<p>You can explicitly mark a nonterminal as optional or repetitive by postfixing
+its name with <code>?</code> and <code>+</code> (respectively)--as in <code>statementlist+</code> or <code>comment?</code>.
+Note that this has no semantic value: use nearley&apos;s EBNF modifiers (<code>:*</code>, <code>:+</code>,
 <code>:?</code>) for that.</p>
-<h3 id="don-t-roll-your-own-unroller">Don’t roll your own unroller</h3>
-<p>If you want to match one or more of a nonterminal, use an EBNF modifier. It’s
+<h3 id="dont-roll-your-own-unroller">
+Don&apos;t roll your own unroller</h3>
+<p>If you want to match one or more of a nonterminal, use an EBNF modifier. It&apos;s
 semantically legible, contextually appropriate and (most importantly) easy.
-It’s very easy to mess up and create an exponentially ambiguous monstrosity
+It&apos;s very easy to mess up and create an exponentially ambiguous monstrosity
 such as</p>
 <pre><code>lotsofletters -&gt; &quot;a&quot; | lotsofletters lotsofletters
-</code></pre><h3 id="postprocess-or-dispose">Postprocess or dispose</h3>
-<p>nearley saves a nested array structure by default, but most of the time that’s
+</code></pre>
+<h3 id="postprocess-or-dispose">
+Postprocess or dispose</h3>
+<p>nearley saves a nested array structure by default, but most of the time that&apos;s
 not what you want. For things like whitespace, you want to throw away all that
 useless information for memory efficiency, so use a postprocessor that just
 returns <code>null</code>. For syntactic sugar and stuff, construct object literals so
 that the code that processes your AST is relatively independent of your
 grammar. Constructing object literals also lets you discard junk (parens,
 etc.).</p>
-<h3 id="remember-charclasses-aren-t-regexes">Remember, charclasses aren’t regexes</h3>
+<h3 id="remember-charclasses-arent-regexes">
+Remember, charclasses aren&apos;t regexes</h3>
 <p>The <code>[a-z]</code> syntax only allows you to use regex-style character classes, not
 actual regular expressions. Nearley fundamentally does not support regexes as
-terminals. Use EBNF modifiers instead–they do what you want.</p>
-<h3 id="debug-with-nearley-test">Debug with nearley-test</h3>
+terminals. Use EBNF modifiers instead--they do what you want.</p>
+<h3 id="debug-with-nearley-test">
+Debug with nearley-test</h3>
 <p>Use the <code>nearley-test</code> script (installs alongside <code>nearleyc</code>) to debug your
 grammars. It lets you inspect the parse tables, and see all the parsings, or
 the point of failure. This is invaluable when you have a subtle ambiguity
 issue.</p>
-<h3 id="don-t-shy-away-from-left-recursion">Don’t shy away from left recursion</h3>
+<h3 id="dont-shy-away-from-left-recursion">
+Don&apos;t shy away from left recursion</h3>
 <p>You were a good little student and you paid attention to your professors when
 they told you never to write grammars like:</p>
 <pre><code>a -&gt; a &quot;something&quot;
-</code></pre><p>because a naïve recursive-descent parser would bork in an infinite loop.
-Nearley, of course, is much better, so you don’t have to worry about that. If
-you’re paranoid about efficiency, you should actually prefer left recursion
-over right recursion (<code>a -&gt; &quot;something&quot; a</code>) because it’s very slightly faster.
-In any case, that’s how you deal with left or right associativity for binary
+</code></pre>
+<p>because a na&#xEF;ve recursive-descent parser would bork in an infinite loop.
+Nearley, of course, is much better, so you don&apos;t have to worry about that. If
+you&apos;re paranoid about efficiency, you should actually prefer left recursion
+over right recursion (<code>a -&gt; &quot;something&quot; a</code>) because it&apos;s very slightly faster.
+In any case, that&apos;s how you deal with left or right associativity for binary
 operators.</p>
-<h3 id="do-shy-away-from-left-recursion">Do shy away from left recursion</h3>
-<p>…if you’re using it where the EBNF <code>:*</code> or <code>:+</code> makes more sense!</p>
-<h3 id="operator-precedence-is-not-black-magic">Operator precedence is not black magic</h3>
-<p>Here’s how you do it: you start with your lowest-precedence operator and work
+<h3 id="do-shy-away-from-left-recursion">
+Do shy away from left recursion</h3>
+<p>...if you&apos;re using it where the EBNF <code>:*</code> or <code>:+</code> makes more sense!</p>
+<h3 id="operator-precedence-is-not-black-magic">
+Operator precedence is not black magic</h3>
+<p>Here&apos;s how you do it: you start with your lowest-precedence operator and work
 your way up to your highest precedence ones. Each operator gets its own
 nonterminal:</p>
 <pre><code>math -&gt; sum
 sum -&gt; sum (&quot;+&quot;|&quot;-&quot;) product | product
 product -&gt; product (&quot;*&quot;|&quot;/&quot;) exp | exp
 exp -&gt; number &quot;^&quot; exp | number # this is right associative!
-</code></pre><p>It should be pretty clear how this works, and how to extend it to different
+</code></pre>
+<p>It should be pretty clear how this works, and how to extend it to different
 types of operators. The main thing is to be careful with your associativity
-direction. Be careful not to write <code>op -&gt; op &quot;$&quot; op</code>, because that’s ambiguous.</p>
+direction. Be careful not to write <code>op -&gt; op &quot;$&quot; op</code>, because that&apos;s ambiguous.</p>
 <p>Introducing non-conflicting unary negation (<code>&quot;5 * -5&quot;</code>) is left as a trivial
 exercise for the enterprising reader.</p>
-<h3 id="comment-your-grammars">Comment your grammars</h3>
-<p>It’s very easy to come back to a grammar a week later and have no idea what
-it’s doing. Leave comments that explain precisely what each nonterminal
+<h3 id="comment-your-grammars">
+Comment your grammars</h3>
+<p>It&apos;s very easy to come back to a grammar a week later and have no idea what
+it&apos;s doing. Leave comments that explain precisely what each nonterminal
 matches, since a clear description will help you debug things in the future.</p>
-<h3 id="use-whitespace-prettily">Use whitespace prettily</h3>
+<h3 id="use-whitespace-prettily">
+Use whitespace prettily</h3>
 <p>Align your <code>-&gt;</code>s and your <code>|</code>s and your <code>{% ... %}</code>s. Future retinas will thank
 you.</p>
-<h3 id="parsing-an-established-language-cheat-">Parsing an established language? Cheat!</h3>
+<h3 id="parsing-an-established-language-cheat">
+Parsing an established language? Cheat!</h3>
 <p>Almost all standards publish syntax guides with an accompanying diagram in
-(E)BNF. It’s worth it to Google around for this. With just a bit of common
+(E)BNF. It&apos;s worth it to Google around for this. With just a bit of common
 sense, you should be able to transliterate it to a <code>.ne</code> file.</p>
 <hr>
 <p>Again, grammar-writing is largely about instinct and experience. The more you
-write, the more you’ll understand how it goes, and the faster you’ll be able to
+write, the more you&apos;ll understand how it goes, and the faster you&apos;ll be able to
 prototype and design.</p>
-
+</body></html>
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
     href="http://hardmath123.github.io">Hardmath123</a> (<a
     href="http://github.com/Hardmath123">Github</a>). You're welcome to
     leave questions, comments, advice, or ideas as Github issues. And
     feel free to fork nearley with your own experiments!<br/>
-    
+
     <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
     <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
 </div>
 
-<script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>
-document.querySelector('#highlight-js').addEventListener('load', function() {
-    [].slice.apply(document.querySelectorAll('pre code')).forEach(function(b) {
-        hljs.highlightBlock(b)
-    })
-})
-</script>
-
 
 <script>
-window.addEventListener('scroll', onScroll)
-window.addEventListener('resize', onScroll)
+window.addEventListener("scroll", onScroll);
+window.addEventListener("resize", onScroll);
 
-var timeout
+var timeout;
 function onScroll(e) {
-    if (timeout) clearTimeout(timeout)
-    timeout = setTimeout(scrollEnd, 50)
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(scrollEnd, 50);
 }
 
 function scrollEnd() {
-  var headings = document.querySelectorAll('h3')
-  var offset = 60
-  for (var i=headings.length; i--; ) {
-    var h3 = headings[i]
+  var headings = document.querySelectorAll("h3");
+  var offset = 60;
+  for (var i = headings.length; i--; ) {
+    var h3 = headings[i];
     if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector('.page-heading-active')
-      if (cur) cur.className = 'page-heading'
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
-      return
+      var cur = document.querySelector(".page-heading-active");
+      if (cur) cur.className = "page-heading";
+      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
+        "page-heading page-heading-active";
+      return;
     }
   }
 }
 </script>
 
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-46120535-5', 'auto');
-ga('send', 'pageview');
+(function(i, s, o, g, r, a, m) {
+  i["GoogleAnalyticsObject"] = r;
+  (i[r] =
+    i[r] ||
+    function() {
+      (i[r].q = i[r].q || []).push(arguments);
+    }),
+    (i[r].l = 1 * new Date());
+  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+  a.async = 1;
+  a.src = g;
+  m.parentNode.insertBefore(a, m);
+})(
+  window,
+  document,
+  "script",
+  "https://www.google-analytics.com/analytics.js",
+  "ga"
+);
+ga("create", "UA-46120535-5", "auto");
+ga("send", "pageview");
 </script>
-

--- a/docs/how-to-grammar-good.html
+++ b/docs/how-to-grammar-good.html
@@ -241,8 +241,6 @@ nav ul a {
     }
 }
 
-/* highlight.js */
-
 .highlight pre {
   display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
 }
@@ -454,25 +452,5 @@ function scrollEnd() {
 </script>
 
 <script>
-(function(i, s, o, g, r, a, m) {
-  i["GoogleAnalyticsObject"] = r;
-  (i[r] =
-    i[r] ||
-    function() {
-      (i[r].q = i[r].q || []).push(arguments);
-    }),
-    (i[r].l = 1 * new Date());
-  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-  a.async = 1;
-  a.src = g;
-  m.parentNode.insertBefore(a, m);
-})(
-  window,
-  document,
-  "script",
-  "https://www.google-analytics.com/analytics.js",
-  "ga"
-);
-ga("create", "UA-46120535-5", "auto");
-ga("send", "pageview");
+(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
 </script>

--- a/docs/how-to-grammar-good.html
+++ b/docs/how-to-grammar-good.html
@@ -504,12 +504,12 @@ prototype and design.</p>
     </script>
 
     <script>
-      (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-      ga('create', 'UA-46120535-5', 'auto');
-      ga('send', 'pageview');
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-46120535-5', 'auto');
+ga('send', 'pageview');
     </script>
+  </div>
+</body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
+@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -142,7 +143,7 @@ code {
     background-color: #eee;
 }
 
-pre code {
+pre code, .highlight pre {
     border-radius: 0.5em;
     padding: 0.5em;
     display: block;
@@ -242,8 +243,9 @@ nav ul a {
 
 /* highlight.js */
 
-.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
-
+.highlight pre {
+  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+}
 
 </style>
 
@@ -256,10 +258,14 @@ nav ul a {
         <li class="page">
             <a href="#" class="page-title-active">Home</a>
             <ul>
-                <li class="page-heading"><a href="#nearley-101">nearley 101</a>
-                <li class="page-heading"><a href="#features">Features</a>
-                <li class="page-heading"><a href="#projects-using-nearley">Projects using nearley</a>
-                <li class="page-heading"><a href="#give-to-nearley">Give to nearley</a>
+                <li class="page-heading"><a href="#nearley-101">
+nearley 101</a></li>
+                <li class="page-heading"><a href="#features">
+Features</a></li>
+                <li class="page-heading"><a href="#projects-using-nearley">
+Projects using nearley</a></li>
+                <li class="page-heading"><a href="#give-to-nearley">
+Give to nearley</a></li>
             </ul>
         </li>
         <li class="page"><a href="/docs/getting-started">Getting started</a>
@@ -276,57 +282,61 @@ nav ul a {
 <div id="main" class="center">
 
 <h2>Home</h2>
-<p><strong>Parsers</strong> turn strings of characters into meaningful data structures (like a
+<html><head></head><body><p><strong>Parsers</strong> turn strings of characters into meaningful data structures (like a
 JSON object!). <strong>nearley</strong> is a <strong>fast</strong>, <strong>feature-rich</strong>, and <strong>modern</strong>
 parser toolkit for JavaScript. nearley is an <a href="https://github.com/npm/npm-collection-staff-picks">npm Staff
 Pick</a>.</p>
-<h3 id="nearley-101">nearley 101</h3>
+<h3 id="nearley-101">
+nearley 101</h3>
 <ol>
 <li>Install: <code>$ npm install -g nearley</code> (or try nearley live in your browser
-<a href="https://omrelli.ug/nearley-playground/">here</a>!)</li>
-<li>Write your grammar:<pre><code class="lang-ne"># Match a CSS color
-# http://www.w3.org/TR/css3-color/#colorunits
-@builtin &quot;whitespace.ne&quot; # `_` means arbitrary amount of whitespace
-@builtin &quot;number.ne&quot;     # `int`, `decimal`, and `percentage` number primitives
-csscolor -&gt; &quot;#&quot; hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit
-          | &quot;#&quot; hexdigit hexdigit hexdigit
-          | &quot;rgb&quot;  _ &quot;(&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;)&quot;
-          | &quot;hsl&quot;  _ &quot;(&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;)&quot;
-          | &quot;rgba&quot; _ &quot;(&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;,&quot; _ decimal _ &quot;)&quot;
-          | &quot;hsla&quot; _ &quot;(&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;,&quot; _ decimal _ &quot;)&quot;
-hexdigit -&gt; [a-fA-F0-9]
-colnum   -&gt; int | percentage
-</code></pre>
+<a href="https://omrelli.ug/nearley-playground/" rel="nofollow">here</a>!)</li>
+<li>Write your grammar:
+<div class="highlight highlight-source-ne"><pre><span class="pl-c"># Match a CSS color</span>
+<span class="pl-c"># http://www.w3.org/TR/css3-color/#colorunits</span>
+<span class="pl-k">@builtin</span> <span class="pl-s">&quot;whitespace.ne&quot;</span> <span class="pl-c"># `_` means arbitrary amount of whitespace</span>
+<span class="pl-k">@builtin</span> <span class="pl-s">&quot;number.ne&quot;</span>     <span class="pl-c"># `int`, `decimal`, and `percentage` number primitives</span>
+<span class="pl-en">csscolor</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;#&quot;</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span>
+          <span class="pl-k">|</span> <span class="pl-s">&quot;#&quot;</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span>
+          <span class="pl-k">|</span> <span class="pl-s">&quot;rgb&quot;</span>  <span class="pl-en">_</span> <span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span>
+          <span class="pl-k">|</span> <span class="pl-s">&quot;hsl&quot;</span>  <span class="pl-en">_</span> <span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span>
+          <span class="pl-k">|</span> <span class="pl-s">&quot;rgba&quot;</span> <span class="pl-en">_</span> <span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">decimal</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span>
+          <span class="pl-k">|</span> <span class="pl-s">&quot;hsla&quot;</span> <span class="pl-en">_</span> <span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">decimal</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span>
+<span class="pl-en">hexdigit</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[a-fA-F0-9]</span>
+<span class="pl-en">colnum</span>   <span class="pl-k">-&gt;</span> <span class="pl-en">int</span> <span class="pl-k">|</span> <span class="pl-en">percentage</span></pre></div>
 </li>
-<li>Compile your grammar:<pre><code class="lang-bash">$ nearleyc csscolor.ne -o csscolor.js
-</code></pre>
+<li>Compile your grammar:
+<div class="highlight highlight-source-shell"><pre>$ nearleyc csscolor.ne -o csscolor.js</pre></div>
 </li>
-<li>Test your grammar:<pre><code class="lang-bash">$ nearley-test -i &quot;#00ff00&quot; csscolor.js
+<li>Test your grammar:
+<div class="highlight highlight-source-shell"><pre>$ nearley-test -i <span class="pl-s"><span class="pl-pds">&quot;</span>#00ff00<span class="pl-pds">&quot;</span></span> csscolor.js
 Parse results:
-[ [ &#39;#&#39;, [ &#39;0&#39; ], [ &#39;0&#39; ], [ &#39;f&#39; ], [ &#39;f&#39; ], [ &#39;0&#39; ], [ &#39;0&#39; ] ] ]
-</code></pre>
+[ [ <span class="pl-s"><span class="pl-pds">&apos;</span>#<span class="pl-pds">&apos;</span></span>, [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>f<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>f<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ] ] ]</pre></div>
 </li>
-<li>Turn your grammar into a generator:<pre><code class="lang-bash">$ nearley-unparse -n 3 csscolor.js
-</code></pre>
+<li>Turn your grammar into a generator:
+<div class="highlight highlight-source-shell"><pre>$ nearley-unparse -n 3 csscolor.js</pre></div>
 <pre><code>#Ab21F2
 rgb  ( -29.889%,7,8172)
 #a40
-</code></pre></li>
-<li>You try it! Type a CSS color here:
-<input type="text" id="parse-input" placeholder="rgba(0, 255, 0, 0.5)" /><pre><code id="parse-output">…and the parsed output will appear here!</code></pre></li>
-<li>Create beautiful railroad diagrams to document your grammar formally.<pre><code class="lang-bash">$ nearley-railroad csscolor.ne -o csscolor.html
 </code></pre>
+</li>
+<li>You try it! Type a CSS color here:
+<div id="user-content-sample-parse"></div>
+</li>
+<li>Create beautiful railroad diagrams to document your grammar formally.
+<div class="highlight highlight-source-shell"><pre>$ nearley-railroad csscolor.ne -o csscolor.html</pre></div>
 See a demo <a href="/www/railroad-demo">here</a>.</li>
 </ol>
-<h3 id="features">Features</h3>
+<h3 id="features">
+Features</h3>
 <ul>
 <li>nearley is the first JS parser to use the <strong>Earley</strong> algorithm (insert your
-own ‘early bird’ pun here). It also implements Joop Leo’s optimizations for
+own &#x2018;early bird&#x2019; pun here). It also implements Joop Leo&apos;s optimizations for
 right-recursion, making it effectively <strong>linear-time</strong> for LL(k) grammars.</li>
-<li>nearley lives happily in <strong>node</strong>, but doesn’t mind the <strong>browser</strong>.</li>
+<li>nearley lives happily in <strong>node</strong>, but doesn&apos;t mind the <strong>browser</strong>.</li>
 <li>nearley outputs <strong>small</strong> files. And its <strong>expressive</strong> DSL comes with
 plenty of <strong>syntactic sugar</strong> to keep your source files short. And sweet.</li>
-<li>nearley’s grammar language is powerful and expressive: you can use
+<li>nearley&apos;s grammar language is powerful and expressive: you can use
 <strong>macros</strong>, import from a large <strong>builtin library</strong> of pre-defined
 parser-pieces, use a <strong>tokenizer</strong> for extra performance, and more!</li>
 <li>nearley is built on an idiomatic <strong>streaming API</strong>. You even have access to
@@ -341,7 +351,8 @@ all the parsings (in a deterministic order!).</li>
 catches a parse-time error, nearley tells you exactly what went wrong and
 where.</li>
 <li>nearley is powerful enough to be <strong>bootstrapped</strong>. That means nearley uses
-nearley to compile parts of nearley. <em>nearleyception!</em></li>
+nearley to compile parts of nearley. <em>nearleyception!</em>
+</li>
 <li>nearley parsers can be inverted to form <strong>generators</strong> which output random
 strings that match a grammar. Useful for writing <strong>test cases</strong>,
 <strong>fuzzers</strong>, and <strong>Mad-Libs</strong>.</li>
@@ -351,7 +362,8 @@ easy-to-understand documentation of your grammar.</li>
 <strong>vim</strong>, <strong>Sublime Text</strong>, <strong>Atom</strong>, and <strong>VS Code</strong>; there are also
 plug-ins for <strong>Webpack</strong> and <strong>gulp</strong>.</li>
 </ul>
-<h3 id="projects-using-nearley">Projects using nearley</h3>
+<h3 id="projects-using-nearley">
+Projects using nearley</h3>
 <p><strong>Artificial Intelligence and NLP</strong>:
 <a href="https://github.com/ChalmersGU-AI-course/shrdlite-course-project">Shrdlite</a> is
 a programming project in Artificial Intelligence, a course given at the
@@ -367,7 +379,7 @@ BibTeX-to-HTML converter,
 <a href="https://github.com/fiduswriter/biblatex-csl-converter">biblatex-csl-converter</a>
 converts between bibtex/CSL/JSON, <a href="https://github.com/gajus/scalpel">scalpel</a>
 parses CSS selectors (powering <a href="https://github.com/airbnb/enzyme">enzyme</a>,
-Airbnb’s React testing tool),
+Airbnb&apos;s React testing tool),
 <a href="https://github.com/waratuman/rfc5545-rrule">rfc5545-rrule</a> helps parse
 iCalendar data, <a href="https://github.com/mangudai/mangudai">mangudai</a> parses RMS
 scripts for Age of Empires II, <a href="https://github.com/r24y/tf-hcl">tf-hcl</a> parses
@@ -396,7 +408,7 @@ programming language, <a href="https://github.com/farskipper/ecmaless">ecmaless<
 easily-extensible language, <a href="https://github.com/xodio/hm-parser">hm-parser</a>
 parses Haskell-like Hindley-Milner type signatures,
 <a href="https://github.com/kozily/web">kozily</a> implements the Oz language,
-<a href="https://stefan1niculae.github.io/abstract-machine/">abstract-machine</a> inspects
+<a href="https://stefan1niculae.github.io/abstract-machine/" rel="nofollow">abstract-machine</a> inspects
 execution models, <a href="https://github.com/Malpaux/fbp-types">fbp-types</a> provides
 typechecking primitives for flow-based systems,
 <a href="https://github.com/sizigi/lp5562">lp5562</a> is an assembler for the TI LP5562
@@ -408,9 +420,9 @@ systems.</p>
 <p><strong>Mathematics</strong>: <a href="https://github.com/andrejewski/solvent">Solvent</a> is a
 powerful desktop calculator,
 <a href="https://github.com/andrejewski/truth-table">Truth-table</a> is a tool to
-visualize propositional logic in truth tables, <a href="http://emunotes.com">Emunotes</a>
+visualize propositional logic in truth tables, <a href="http://emunotes.com" rel="nofollow">Emunotes</a>
 is a personal Wiki with inline graphing and computation,
-<a href="https://kgram.github.io/react-equation/">react-equation</a> parses and renders
+<a href="https://kgram.github.io/react-equation/" rel="nofollow">react-equation</a> parses and renders
 equations in React, <a href="https://github.com/cemulate/the-mlab">the mLab</a> generates
 category theory papers.</p>
 <p><strong>Domain-specific languages</strong>: <a href="https://github.com/jcorbin/hexant">Hexant</a> is a
@@ -421,7 +433,7 @@ create board games, <a href="https://github.com/danigb/in-seconds">in-seconds</a
 time calculator for music applications,
 <a href="https://github.com/bumbu/website-spec">website-spec</a> is a tool for functional
 web testing, <a href="https://github.com/gajus/pianola">pianola</a> allows declarative
-function composition, <a href="https://idyll-lang.github.io/idyll/">idyll</a> is a markup
+function composition, <a href="https://idyll-lang.github.io/idyll/" rel="nofollow">idyll</a> is a markup
 language for data-driven documents,
 <a href="https://github.com/affinipay/virtsecgroup">virtsecgroup</a> provides virtual AWS
 security groups, <a href="https://github.com/Pwootage/deadfad">deadfad</a> is a hex editor
@@ -435,88 +447,110 @@ provides syntactic grep for JavaScript,
 <a href="https://github.com/monostable/electro-grammar">electro-grammar</a> parses
 descriptions of electronic components like resistors and capacitors,
 <a href="https://github.com/accordproject">cicero</a> helps create smart legal contracts.</p>
-<p><strong>Parsing libraries</strong>: <a href="http://nearley.js.org">nearley</a> is a parser toolkit for
+<p><strong>Parsing libraries</strong>: <a href="http://nearley.js.org" rel="nofollow">nearley</a> is a parser toolkit for
 JavaScript. It has a nearley-based DSL to specify parsers.</p>
-<!--Excited? Get started on [Github](https://github.com/Hardmath123/nearley),
-visit us on [npm](http://npmjs.org/package/nearley), explore nearley in your
-browser on the [playground](https://omrelli.ug/nearley-playground/), or try out
-the [calculator demo](examples/calculator/) for more action.-->
-<h3 id="give-to-nearley">Give to nearley</h3>
-<p>nearley has been maintained by volunteers since 2014. If you want to help
-support us, contact <strong>@kach</strong> or <strong>@tjvr</strong> on GitHub. We’ll send over our
-PayPal information – and maybe something nice. :-).</p>
 
+<h3 id="give-to-nearley">
+Give to nearley</h3>
+<p>nearley has been maintained by volunteers since 2014. If you want to help
+support us, contact <strong>@kach</strong> or <strong>@tjvr</strong> on GitHub. We&apos;ll send over our
+PayPal information -- and maybe something nice. :-).</p>
+</body></html>
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
     href="http://hardmath123.github.io">Hardmath123</a> (<a
     href="http://github.com/Hardmath123">Github</a>). You're welcome to
     leave questions, comments, advice, or ideas as Github issues. And
     feel free to fork nearley with your own experiments!<br/>
-    
+
     <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
     <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
 </div>
 
-<script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>
-document.querySelector('#highlight-js').addEventListener('load', function() {
-    [].slice.apply(document.querySelectorAll('pre code')).forEach(function(b) {
-        hljs.highlightBlock(b)
-    })
-})
-</script>
-
 <script charset="utf-8" src="/lib/nearley.js"></script>
 <script charset="utf-8" src="/examples/js/csscolor.js"></script>
 <script type="text/javascript">
-window.addEventListener('load', function() {
-    document.getElementById('parse-input').addEventListener('keyup', function() {
+window.addEventListener(
+  "load",
+  function() {
+    document.getElementById("user-content-sample-parse").innerHTML =
+      '<input type="text" id="parse-input" placeholder="rgba(0, 255, 0, 0.5)" />\n\
+<pre><code id="parse-output">…and the parsed output will appear here!</code></pre>';
+    document.getElementById("parse-input").addEventListener(
+      "keyup",
+      function() {
         // $ ./bin/nearleyc.js examples/csscolor.ne -o examples/js/csscolor.js
         var str = this.value;
-        var parser = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
+        var parser = new nearley.Parser(
+          grammar.ParserRules,
+          grammar.ParserStart
+        );
         try {
-            parser.feed(str);
-            document.getElementById('parse-output').innerHTML = JSON.stringify(parser.results, null, 2);
-            this.style.color = "#559";
-        } catch(e) {
-            document.getElementById('parse-output').innerHTML = "";
-            this.style.color = "red";
+          parser.feed(str);
+          document.getElementById("parse-output").innerHTML = JSON.stringify(
+            parser.results,
+            null,
+            2
+          );
+          this.style.color = "#559";
+        } catch (e) {
+          document.getElementById("parse-output").innerHTML = "";
+          this.style.color = "red";
         }
-    }, false);
-}, false);
+      },
+      false
+    );
+  },
+  false
+);
 </script>
 
 <script>
-window.addEventListener('scroll', onScroll)
-window.addEventListener('resize', onScroll)
+window.addEventListener("scroll", onScroll);
+window.addEventListener("resize", onScroll);
 
-var timeout
+var timeout;
 function onScroll(e) {
-    if (timeout) clearTimeout(timeout)
-    timeout = setTimeout(scrollEnd, 50)
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(scrollEnd, 50);
 }
 
 function scrollEnd() {
-  var headings = document.querySelectorAll('h3')
-  var offset = 60
-  for (var i=headings.length; i--; ) {
-    var h3 = headings[i]
+  var headings = document.querySelectorAll("h3");
+  var offset = 60;
+  for (var i = headings.length; i--; ) {
+    var h3 = headings[i];
     if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector('.page-heading-active')
-      if (cur) cur.className = 'page-heading'
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
-      return
+      var cur = document.querySelector(".page-heading-active");
+      if (cur) cur.className = "page-heading";
+      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
+        "page-heading page-heading-active";
+      return;
     }
   }
 }
 </script>
 
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-46120535-5', 'auto');
-ga('send', 'pageview');
+(function(i, s, o, g, r, a, m) {
+  i["GoogleAnalyticsObject"] = r;
+  (i[r] =
+    i[r] ||
+    function() {
+      (i[r].q = i[r].q || []).push(arguments);
+    }),
+    (i[r].l = 1 * new Date());
+  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+  a.async = 1;
+  a.src = g;
+  m.parentNode.insertBefore(a, m);
+})(
+  window,
+  document,
+  "script",
+  "https://www.google-analytics.com/analytics.js",
+  "ga"
+);
+ga("create", "UA-46120535-5", "auto");
+ga("send", "pageview");
 </script>
-

--- a/docs/index.html
+++ b/docs/index.html
@@ -565,12 +565,12 @@ PayPal information – and maybe something nice. :-).</p>
     </script>
 
     <script>
-      (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-      ga('create', 'UA-46120535-5', 'auto');
-      ga('send', 'pageview');
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-46120535-5', 'auto');
+ga('send', 'pageview');
     </script>
+  </div>
+</body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -241,8 +241,6 @@ nav ul a {
     }
 }
 
-/* highlight.js */
-
 .highlight pre {
   display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
 }
@@ -331,7 +329,7 @@ See a demo <a href="/www/railroad-demo">here</a>.</li>
 Features</h3>
 <ul>
 <li>nearley is the first JS parser to use the <strong>Earley</strong> algorithm (insert your
-own &#x2018;early bird&#x2019; pun here). It also implements Joop Leo&apos;s optimizations for
+own &#x2018;earley bird&#x2019; pun here). It also implements Joop Leo&apos;s optimizations for
 right-recursion, making it effectively <strong>linear-time</strong> for LL(k) grammars.</li>
 <li>nearley lives happily in <strong>node</strong>, but doesn&apos;t mind the <strong>browser</strong>.</li>
 <li>nearley outputs <strong>small</strong> files. And its <strong>expressive</strong> DSL comes with
@@ -532,25 +530,5 @@ function scrollEnd() {
 </script>
 
 <script>
-(function(i, s, o, g, r, a, m) {
-  i["GoogleAnalyticsObject"] = r;
-  (i[r] =
-    i[r] ||
-    function() {
-      (i[r].q = i[r].q || []).push(arguments);
-    }),
-    (i[r].l = 1 * new Date());
-  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-  a.async = 1;
-  a.src = g;
-  m.parentNode.insertBefore(a, m);
-})(
-  window,
-  document,
-  "script",
-  "https://www.google-analytics.com/analytics.js",
-  "ga"
-);
-ga("create", "UA-46120535-5", "auto");
-ga("send", "pageview");
+(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
 </script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <title>Home - nearley.js - JS Parsing Toolkit</title>
-<meta charset="utf-8"/>
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
-@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
+  @import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -145,11 +145,23 @@ code {
 
 pre code, .highlight pre {
     border-radius: 0.5em;
-    padding: 0.5em;
+    margin: 5px;
+    padding: 10px;
     display: block;
     overflow: auto;
 }
 
+.highlight pre {
+    padding: 0;
+    margin: 0;
+    display: block;
+    overflow-x: auto;
+}
+
+pre > code > pre > code {
+    padding: 0;
+    margin: 0;
+}
 
 ol {
     counter-reset: tutorial-counter;
@@ -206,7 +218,7 @@ nav ul a {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 0.25em 0.5em; */
+    padding: 0.25em 0.5em;
 }
 .page {
     display: block;
@@ -241,56 +253,105 @@ nav ul a {
     }
 }
 
-.highlight pre {
-  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+code pre {
+    margin: 0;
 }
-
 </style>
 
-<body class="docs-page">
+<body class="docs-page" >
 
-<a href="https://github.com/kach/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-<nav id="nav">
-    <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">2.12.1</span></a></h1>
+  <a href="https://github.com/kach/nearley" class="github-corner">
+    <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg>
+  </a>
+  <style>
+    .github-corner:hover .octo-arm {
+      animation: octocat-wave 560ms ease-in-out
+    }
+
+    @keyframes octocat-wave {
+      0%,
+      100% {
+        transform: rotate(0)
+      }
+      20%,
+      60% {
+        transform: rotate(-25deg)
+      }
+      40%,
+      80% {
+        transform: rotate(10deg)
+      }
+    }
+
+    @media (max-width:500px) {
+      .github-corner:hover .octo-arm {
+        animation: none
+      }
+      .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out
+      }
+    }
+  </style>
+  <nav id="nav">
+    <h1>
+      <a href="/">nearley
+        <span style="color: #559;">.js</span>
+        <span id="version">2.12.1</span>
+      </a>
+    </h1>
     <ul>
-        <li class="page">
-            <a href="#" class="page-title-active">Home</a>
-            <ul>
-                <li class="page-heading"><a href="#nearley-101">
-nearley 101</a></li>
-                <li class="page-heading"><a href="#features">
-Features</a></li>
-                <li class="page-heading"><a href="#projects-using-nearley">
-Projects using nearley</a></li>
-                <li class="page-heading"><a href="#give-to-nearley">
-Give to nearley</a></li>
-            </ul>
+       
+      <li class="page">
+        <a href="#" class="page-title-active">Home</a>
+        <ul>
+          <li class="page-heading">
+            <a href="#nearley-101">nearley 101</a>
+          <li class="page-heading">
+            <a href="#features">Features</a>
+          <li class="page-heading">
+            <a href="#projects-using-nearley">Projects using nearley</a>
+          <li class="page-heading">
+            <a href="#give-to-nearley">Give to nearley</a>
+        </ul>
         </li>
-        <li class="page"><a href="/docs/getting-started">Getting started</a>
-        <li class="page"><a href="/docs/grammar">Writing a parser</a>
-        <li class="page"><a href="/docs/parser">Using a parser</a>
-        <li class="page"><a href="/docs/tokenizers">Tokenizers</a>
-        <li class="page"><a href="/docs/tooling">Tooling</a>
-        <li class="page"><a href="/docs/how-to-grammar-good">How to grammar good</a>
-        <li class="page"><a href="/docs/using-in-frontend">Compiling in browsers</a>
-        <li class="page"><a href="/docs/glossary">Glossary</a>
+          <li class="page">
+          <a href="/docs/getting-started">Getting started</a>
+                    <li class="page">
+          <a href="/docs/grammar">Writing a parser</a>
+                    <li class="page">
+          <a href="/docs/parser">Using a parser</a>
+                    <li class="page">
+          <a href="/docs/tokenizers">Tokenizers</a>
+                    <li class="page">
+          <a href="/docs/tooling">Tooling</a>
+                    <li class="page">
+          <a href="/docs/how-to-grammar-good">How to grammar good</a>
+                    <li class="page">
+          <a href="/docs/using-in-frontend">Compiling in browsers</a>
+                    <li class="page">
+          <a href="/docs/glossary">Glossary</a>
+           
     </ul>
-</nav>
+  </nav>
 
-<div id="main" class="center">
+  <div id="main" class="center">
 
-<h2>Home</h2>
-<html><head></head><body><p><strong>Parsers</strong> turn strings of characters into meaningful data structures (like a
+    <h2>Home</h2>
+    <p><strong>Parsers</strong> turn strings of characters into meaningful data structures (like a
 JSON object!). <strong>nearley</strong> is a <strong>fast</strong>, <strong>feature-rich</strong>, and <strong>modern</strong>
 parser toolkit for JavaScript. nearley is an <a href="https://github.com/npm/npm-collection-staff-picks">npm Staff
 Pick</a>.</p>
-<h3 id="nearley-101">
-nearley 101</h3>
+<h3 id="nearley-101">nearley 101</h3>
 <ol>
 <li>Install: <code>$ npm install -g nearley</code> (or try nearley live in your browser
-<a href="https://omrelli.ug/nearley-playground/" rel="nofollow">here</a>!)</li>
-<li>Write your grammar:
-<div class="highlight highlight-source-ne"><pre><span class="pl-c"># Match a CSS color</span>
+<a href="https://omrelli.ug/nearley-playground/">here</a>!)</li>
+<li>Write your grammar:<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-c"># Match a CSS color</span>
 <span class="pl-c"># http://www.w3.org/TR/css3-color/#colorunits</span>
 <span class="pl-k">@builtin</span> <span class="pl-s">&quot;whitespace.ne&quot;</span> <span class="pl-c"># `_` means arbitrary amount of whitespace</span>
 <span class="pl-k">@builtin</span> <span class="pl-s">&quot;number.ne&quot;</span>     <span class="pl-c"># `int`, `decimal`, and `percentage` number primitives</span>
@@ -301,40 +362,33 @@ nearley 101</h3>
           <span class="pl-k">|</span> <span class="pl-s">&quot;rgba&quot;</span> <span class="pl-en">_</span> <span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">decimal</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span>
           <span class="pl-k">|</span> <span class="pl-s">&quot;hsla&quot;</span> <span class="pl-en">_</span> <span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">decimal</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span>
 <span class="pl-en">hexdigit</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[a-fA-F0-9]</span>
-<span class="pl-en">colnum</span>   <span class="pl-k">-&gt;</span> <span class="pl-en">int</span> <span class="pl-k">|</span> <span class="pl-en">percentage</span></pre></div>
+<span class="pl-en">colnum</span>   <span class="pl-k">-&gt;</span> <span class="pl-en">int</span> <span class="pl-k">|</span> <span class="pl-en">percentage</span></pre></div></code></pre>
 </li>
-<li>Compile your grammar:
-<div class="highlight highlight-source-shell"><pre>$ nearleyc csscolor.ne -o csscolor.js</pre></div>
+<li>Compile your grammar:<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ nearleyc csscolor.ne -o csscolor.js</pre></div></code></pre>
 </li>
-<li>Test your grammar:
-<div class="highlight highlight-source-shell"><pre>$ nearley-test -i <span class="pl-s"><span class="pl-pds">&quot;</span>#00ff00<span class="pl-pds">&quot;</span></span> csscolor.js
+<li>Test your grammar:<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ nearley-test -i <span class="pl-s"><span class="pl-pds">&quot;</span>#00ff00<span class="pl-pds">&quot;</span></span> csscolor.js
 Parse results:
-[ [ <span class="pl-s"><span class="pl-pds">&apos;</span>#<span class="pl-pds">&apos;</span></span>, [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>f<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>f<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ] ] ]</pre></div>
+[ [ <span class="pl-s"><span class="pl-pds">&apos;</span>#<span class="pl-pds">&apos;</span></span>, [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>f<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>f<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ] ] ]</pre></div></code></pre>
 </li>
-<li>Turn your grammar into a generator:
-<div class="highlight highlight-source-shell"><pre>$ nearley-unparse -n 3 csscolor.js</pre></div>
-<pre><code>#Ab21F2
+<li>Turn your grammar into a generator:<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ nearley-unparse -n 3 csscolor.js</pre></div></code></pre>
+<pre><code><pre><code>#Ab21F2
 rgb  ( -29.889%,7,8172)
 #a40
-</code></pre>
-</li>
-<li>You try it! Type a CSS color here:
-<div id="user-content-sample-parse"></div>
-</li>
-<li>Create beautiful railroad diagrams to document your grammar formally.
-<div class="highlight highlight-source-shell"><pre>$ nearley-railroad csscolor.ne -o csscolor.html</pre></div>
+</code></pre></code></pre></li>
+<li>You try it! Type a CSS color here: <input type="text" id="parse-input" placeholder="rgba(0, 255, 0, 0.5)" />
+<pre><code id="parse-output">…and the parsed output will appear here!</code></pre></li>
+<li>Create beautiful railroad diagrams to document your grammar formally.<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ nearley-railroad csscolor.ne -o csscolor.html</pre></div></code></pre>
 See a demo <a href="/www/railroad-demo">here</a>.</li>
 </ol>
-<h3 id="features">
-Features</h3>
+<h3 id="features">Features</h3>
 <ul>
 <li>nearley is the first JS parser to use the <strong>Earley</strong> algorithm (insert your
-own &#x2018;earley bird&#x2019; pun here). It also implements Joop Leo&apos;s optimizations for
+own ‘earley bird’ pun here). It also implements Joop Leo’s optimizations for
 right-recursion, making it effectively <strong>linear-time</strong> for LL(k) grammars.</li>
-<li>nearley lives happily in <strong>node</strong>, but doesn&apos;t mind the <strong>browser</strong>.</li>
+<li>nearley lives happily in <strong>node</strong>, but doesn’t mind the <strong>browser</strong>.</li>
 <li>nearley outputs <strong>small</strong> files. And its <strong>expressive</strong> DSL comes with
 plenty of <strong>syntactic sugar</strong> to keep your source files short. And sweet.</li>
-<li>nearley&apos;s grammar language is powerful and expressive: you can use
+<li>nearley’s grammar language is powerful and expressive: you can use
 <strong>macros</strong>, import from a large <strong>builtin library</strong> of pre-defined
 parser-pieces, use a <strong>tokenizer</strong> for extra performance, and more!</li>
 <li>nearley is built on an idiomatic <strong>streaming API</strong>. You even have access to
@@ -349,8 +403,7 @@ all the parsings (in a deterministic order!).</li>
 catches a parse-time error, nearley tells you exactly what went wrong and
 where.</li>
 <li>nearley is powerful enough to be <strong>bootstrapped</strong>. That means nearley uses
-nearley to compile parts of nearley. <em>nearleyception!</em>
-</li>
+nearley to compile parts of nearley. <em>nearleyception!</em></li>
 <li>nearley parsers can be inverted to form <strong>generators</strong> which output random
 strings that match a grammar. Useful for writing <strong>test cases</strong>,
 <strong>fuzzers</strong>, and <strong>Mad-Libs</strong>.</li>
@@ -360,8 +413,7 @@ easy-to-understand documentation of your grammar.</li>
 <strong>vim</strong>, <strong>Sublime Text</strong>, <strong>Atom</strong>, and <strong>VS Code</strong>; there are also
 plug-ins for <strong>Webpack</strong> and <strong>gulp</strong>.</li>
 </ul>
-<h3 id="projects-using-nearley">
-Projects using nearley</h3>
+<h3 id="projects-using-nearley">Projects using nearley</h3>
 <p><strong>Artificial Intelligence and NLP</strong>:
 <a href="https://github.com/ChalmersGU-AI-course/shrdlite-course-project">Shrdlite</a> is
 a programming project in Artificial Intelligence, a course given at the
@@ -377,7 +429,7 @@ BibTeX-to-HTML converter,
 <a href="https://github.com/fiduswriter/biblatex-csl-converter">biblatex-csl-converter</a>
 converts between bibtex/CSL/JSON, <a href="https://github.com/gajus/scalpel">scalpel</a>
 parses CSS selectors (powering <a href="https://github.com/airbnb/enzyme">enzyme</a>,
-Airbnb&apos;s React testing tool),
+Airbnb’s React testing tool),
 <a href="https://github.com/waratuman/rfc5545-rrule">rfc5545-rrule</a> helps parse
 iCalendar data, <a href="https://github.com/mangudai/mangudai">mangudai</a> parses RMS
 scripts for Age of Empires II, <a href="https://github.com/r24y/tf-hcl">tf-hcl</a> parses
@@ -406,7 +458,7 @@ programming language, <a href="https://github.com/farskipper/ecmaless">ecmaless<
 easily-extensible language, <a href="https://github.com/xodio/hm-parser">hm-parser</a>
 parses Haskell-like Hindley-Milner type signatures,
 <a href="https://github.com/kozily/web">kozily</a> implements the Oz language,
-<a href="https://stefan1niculae.github.io/abstract-machine/" rel="nofollow">abstract-machine</a> inspects
+<a href="https://stefan1niculae.github.io/abstract-machine/">abstract-machine</a> inspects
 execution models, <a href="https://github.com/Malpaux/fbp-types">fbp-types</a> provides
 typechecking primitives for flow-based systems,
 <a href="https://github.com/sizigi/lp5562">lp5562</a> is an assembler for the TI LP5562
@@ -418,9 +470,9 @@ systems.</p>
 <p><strong>Mathematics</strong>: <a href="https://github.com/andrejewski/solvent">Solvent</a> is a
 powerful desktop calculator,
 <a href="https://github.com/andrejewski/truth-table">Truth-table</a> is a tool to
-visualize propositional logic in truth tables, <a href="http://emunotes.com" rel="nofollow">Emunotes</a>
+visualize propositional logic in truth tables, <a href="http://emunotes.com">Emunotes</a>
 is a personal Wiki with inline graphing and computation,
-<a href="https://kgram.github.io/react-equation/" rel="nofollow">react-equation</a> parses and renders
+<a href="https://kgram.github.io/react-equation/">react-equation</a> parses and renders
 equations in React, <a href="https://github.com/cemulate/the-mlab">the mLab</a> generates
 category theory papers.</p>
 <p><strong>Domain-specific languages</strong>: <a href="https://github.com/jcorbin/hexant">Hexant</a> is a
@@ -431,7 +483,7 @@ create board games, <a href="https://github.com/danigb/in-seconds">in-seconds</a
 time calculator for music applications,
 <a href="https://github.com/bumbu/website-spec">website-spec</a> is a tool for functional
 web testing, <a href="https://github.com/gajus/pianola">pianola</a> allows declarative
-function composition, <a href="https://idyll-lang.github.io/idyll/" rel="nofollow">idyll</a> is a markup
+function composition, <a href="https://idyll-lang.github.io/idyll/">idyll</a> is a markup
 language for data-driven documents,
 <a href="https://github.com/affinipay/virtsecgroup">virtsecgroup</a> provides virtual AWS
 security groups, <a href="https://github.com/Pwootage/deadfad">deadfad</a> is a hex editor
@@ -445,90 +497,80 @@ provides syntactic grep for JavaScript,
 <a href="https://github.com/monostable/electro-grammar">electro-grammar</a> parses
 descriptions of electronic components like resistors and capacitors,
 <a href="https://github.com/accordproject">cicero</a> helps create smart legal contracts.</p>
-<p><strong>Parsing libraries</strong>: <a href="http://nearley.js.org" rel="nofollow">nearley</a> is a parser toolkit for
+<p><strong>Parsing libraries</strong>: <a href="http://nearley.js.org">nearley</a> is a parser toolkit for
 JavaScript. It has a nearley-based DSL to specify parsers.</p>
+<!--Excited? Get started on [Github](https://github.com/Hardmath123/nearley),
+visit us on [npm](http://npmjs.org/package/nearley), explore nearley in your
+browser on the [playground](https://omrelli.ug/nearley-playground/), or try out
+the [calculator demo](examples/calculator/) for more action.-->
 
-<h3 id="give-to-nearley">
-Give to nearley</h3>
+<h3 id="give-to-nearley">Give to nearley</h3>
 <p>nearley has been maintained by volunteers since 2014. If you want to help
-support us, contact <strong>@kach</strong> or <strong>@tjvr</strong> on GitHub. We&apos;ll send over our
-PayPal information -- and maybe something nice. :-).</p>
-</body></html>
+support us, contact <strong>@kach</strong> or <strong>@tjvr</strong> on GitHub. We’ll send over our
+PayPal information – and maybe something nice. :-).</p>
 
-    <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
-    href="http://hardmath123.github.io">Hardmath123</a> (<a
-    href="http://github.com/Hardmath123">Github</a>). You're welcome to
-    leave questions, comments, advice, or ideas as Github issues. And
-    feel free to fork nearley with your own experiments!<br/>
 
-    <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
-    <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
-</div>
+    <div id="footer">
+      <p>nearley is MIT-licensed. It's maintained by
+        <a href="http://hardmath123.github.io">Hardmath123</a> (
+        <a href="http://github.com/Hardmath123">Github</a>). You're welcome to leave questions, comments, advice, or ideas as Github issues. And feel free to fork
+        nearley with your own experiments!
+        <br/>
 
-<script charset="utf-8" src="/lib/nearley.js"></script>
-<script charset="utf-8" src="/examples/js/csscolor.js"></script>
-<script type="text/javascript">
-window.addEventListener(
-  "load",
-  function() {
-    document.getElementById("user-content-sample-parse").innerHTML =
-      '<input type="text" id="parse-input" placeholder="rgba(0, 255, 0, 0.5)" />\n\
-<pre><code id="parse-output">…and the parsed output will appear here!</code></pre>';
-    document.getElementById("parse-input").addEventListener(
-      "keyup",
-      function() {
-        // $ ./bin/nearleyc.js examples/csscolor.ne -o examples/js/csscolor.js
-        var str = this.value;
-        var parser = new nearley.Parser(
-          grammar.ParserRules,
-          grammar.ParserStart
-        );
-        try {
-          parser.feed(str);
-          document.getElementById("parse-output").innerHTML = JSON.stringify(
-            parser.results,
-            null,
-            2
-          );
-          this.style.color = "#559";
-        } catch (e) {
-          document.getElementById("parse-output").innerHTML = "";
-          this.style.color = "red";
+        <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
+          <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo" />
+        </a>
+    </div>
+    <script charset="utf-8" src="/lib/nearley.js"></script>
+    <script charset="utf-8" src="/examples/js/csscolor.js"></script>
+    <script type="text/javascript">
+      window.addEventListener('load', function () {
+        document.getElementById('parse-input').addEventListener('keyup', function () {
+          // $ ./bin/nearleyc.js examples/csscolor.ne -o examples/js/csscolor.js
+          var str = this.value;
+          var parser = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
+          try {
+            parser.feed(str);
+            document.getElementById('parse-output').innerHTML = JSON.stringify(parser.results, null, 2);
+            this.style.color = "#559";
+          } catch (e) {
+            document.getElementById('parse-output').innerHTML = "";
+            this.style.color = "red";
+          }
+        }, false);
+      }, false);
+    </script>
+
+    <script>
+      window.addEventListener('scroll', onScroll)
+      window.addEventListener('resize', onScroll)
+      var timeout
+      function onScroll(e) {
+        if (timeout) clearTimeout(timeout)
+        timeout = setTimeout(scrollEnd, 50)
+      }
+      function scrollEnd() {
+        var headings = document.querySelectorAll('h3')
+        var offset = 60
+        for (var i = headings.length; i--;) {
+          var h3 = headings[i]
+          if (h3.offsetTop < window.scrollY + offset) {
+            var cur = document.querySelector('.page-heading-active')
+            if (cur) cur.className = 'page-heading'
+            document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
+            return
+          }
         }
-      },
-      false
-    );
-  },
-  false
-);
-</script>
+      }
+    </script>
 
-<script>
-window.addEventListener("scroll", onScroll);
-window.addEventListener("resize", onScroll);
-
-var timeout;
-function onScroll(e) {
-  if (timeout) clearTimeout(timeout);
-  timeout = setTimeout(scrollEnd, 50);
-}
-
-function scrollEnd() {
-  var headings = document.querySelectorAll("h3");
-  var offset = 60;
-  for (var i = headings.length; i--; ) {
-    var h3 = headings[i];
-    if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector(".page-heading-active");
-      if (cur) cur.className = "page-heading";
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
-        "page-heading page-heading-active";
-      return;
-    }
-  }
-}
-</script>
-
-<script>
-(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
-</script>
+    <script>
+      (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-46120535-5', 'auto');
+      ga('send', 'pageview');
+    </script>

--- a/docs/layouts/template.html
+++ b/docs/layouts/template.html
@@ -114,25 +114,5 @@ function scrollEnd() {
 </script>
 
 <script>
-(function(i, s, o, g, r, a, m) {
-  i["GoogleAnalyticsObject"] = r;
-  (i[r] =
-    i[r] ||
-    function() {
-      (i[r].q = i[r].q || []).push(arguments);
-    }),
-    (i[r].l = 1 * new Date());
-  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-  a.async = 1;
-  a.src = g;
-  m.parentNode.insertBefore(a, m);
-})(
-  window,
-  document,
-  "script",
-  "https://www.google-analytics.com/analytics.js",
-  "ga"
-);
-ga("create", "UA-46120535-5", "auto");
-ga("send", "pageview");
+(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
 </script>

--- a/docs/layouts/template.html
+++ b/docs/layouts/template.html
@@ -136,12 +136,12 @@
     </script>
 
     <script>
-      (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-      ga('create', 'UA-46120535-5', 'auto');
-      ga('send', 'pageview');
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-46120535-5', 'auto');
+ga('send', 'pageview');
     </script>
+  </div>
+</body>

--- a/docs/layouts/template.html
+++ b/docs/layouts/template.html
@@ -20,7 +20,7 @@
             {{#if headings.length}}
             <ul>
                 {{#each headings}}
-                <li class="page-heading"><a href="#{{id}}">{{text}}</a>
+                <li class="page-heading"><a href="#{{id}}">{{text}}</a></li>
                 {{/each}}
             </ul>
             {{/if}}
@@ -42,73 +42,97 @@
     href="http://github.com/Hardmath123">Github</a>). You're welcome to
     leave questions, comments, advice, or ideas as Github issues. And
     feel free to fork nearley with your own experiments!<br/>
-    
+
     <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
     <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
 </div>
-
-<script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>
-document.querySelector('#highlight-js').addEventListener('load', function() {
-    [].slice.apply(document.querySelectorAll('pre code')).forEach(function(b) {
-        hljs.highlightBlock(b)
-    })
-})
-</script>
 
 {{#if isDemoPage}}
 <script charset="utf-8" src="/lib/nearley.js"></script>
 <script charset="utf-8" src="/examples/js/csscolor.js"></script>
 <script type="text/javascript">
-window.addEventListener('load', function() {
-    document.getElementById('parse-input').addEventListener('keyup', function() {
+window.addEventListener(
+  "load",
+  function() {
+    document.getElementById("user-content-sample-parse").innerHTML =
+      '<input type="text" id="parse-input" placeholder="rgba(0, 255, 0, 0.5)" />\n\
+<pre><code id="parse-output">…and the parsed output will appear here!</code></pre>';
+    document.getElementById("parse-input").addEventListener(
+      "keyup",
+      function() {
         // $ ./bin/nearleyc.js examples/csscolor.ne -o examples/js/csscolor.js
         var str = this.value;
-        var parser = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
+        var parser = new nearley.Parser(
+          grammar.ParserRules,
+          grammar.ParserStart
+        );
         try {
-            parser.feed(str);
-            document.getElementById('parse-output').innerHTML = JSON.stringify(parser.results, null, 2);
-            this.style.color = "#559";
-        } catch(e) {
-            document.getElementById('parse-output').innerHTML = "";
-            this.style.color = "red";
+          parser.feed(str);
+          document.getElementById("parse-output").innerHTML = JSON.stringify(
+            parser.results,
+            null,
+            2
+          );
+          this.style.color = "#559";
+        } catch (e) {
+          document.getElementById("parse-output").innerHTML = "";
+          this.style.color = "red";
         }
-    }, false);
-}, false);
+      },
+      false
+    );
+  },
+  false
+);
 </script>
 {{/if}}
 
 <script>
-window.addEventListener('scroll', onScroll)
-window.addEventListener('resize', onScroll)
+window.addEventListener("scroll", onScroll);
+window.addEventListener("resize", onScroll);
 
-var timeout
+var timeout;
 function onScroll(e) {
-    if (timeout) clearTimeout(timeout)
-    timeout = setTimeout(scrollEnd, 50)
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(scrollEnd, 50);
 }
 
 function scrollEnd() {
-  var headings = document.querySelectorAll('h3')
-  var offset = 60
-  for (var i=headings.length; i--; ) {
-    var h3 = headings[i]
+  var headings = document.querySelectorAll("h3");
+  var offset = 60;
+  for (var i = headings.length; i--; ) {
+    var h3 = headings[i];
     if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector('.page-heading-active')
-      if (cur) cur.className = 'page-heading'
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
-      return
+      var cur = document.querySelector(".page-heading-active");
+      if (cur) cur.className = "page-heading";
+      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
+        "page-heading page-heading-active";
+      return;
     }
   }
 }
 </script>
 
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-46120535-5', 'auto');
-ga('send', 'pageview');
+(function(i, s, o, g, r, a, m) {
+  i["GoogleAnalyticsObject"] = r;
+  (i[r] =
+    i[r] ||
+    function() {
+      (i[r].q = i[r].q || []).push(arguments);
+    }),
+    (i[r].l = 1 * new Date());
+  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+  a.async = 1;
+  a.src = g;
+  m.parentNode.insertBefore(a, m);
+})(
+  window,
+  document,
+  "script",
+  "https://www.google-analytics.com/analytics.js",
+  "ga"
+);
+ga("create", "UA-46120535-5", "auto");
+ga("send", "pageview");
 </script>
-

--- a/docs/layouts/template.html
+++ b/docs/layouts/template.html
@@ -1,118 +1,147 @@
 <!DOCTYPE html>
 <title>{{#if title}}{{title}} - {{/if}}nearley.js - JS Parsing Toolkit</title>
-<meta charset="utf-8"/>
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
-{{{css}}}
+  {{{css}}}
 </style>
 
-<body{{#if isDoc}} class="docs-page"{{/if}}>
+<body{{#if isDoc}} class="docs-page" {{/if}}>
 
-<a href="https://github.com/kach/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-<nav id="nav">
-    <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">{{version}}</span></a></h1>
+  <a href="https://github.com/kach/nearley" class="github-corner">
+    <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg>
+  </a>
+  <style>
+    .github-corner:hover .octo-arm {
+      animation: octocat-wave 560ms ease-in-out
+    }
+
+    @keyframes octocat-wave {
+      0%,
+      100% {
+        transform: rotate(0)
+      }
+      20%,
+      60% {
+        transform: rotate(-25deg)
+      }
+      40%,
+      80% {
+        transform: rotate(10deg)
+      }
+    }
+
+    @media (max-width:500px) {
+      .github-corner:hover .octo-arm {
+        animation: none
+      }
+      .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out
+      }
+    }
+  </style>
+  <nav id="nav">
+    <h1>
+      <a href="/">nearley
+        <span style="color: #559;">.js</span>
+        <span id="version">{{version}}</span>
+      </a>
+    </h1>
     <ul>
-    {{#each docs}}
-        {{#if (eq title ../title)}}
-        <li class="page">
-            <a href="#" class="page-title-active">{{title}}</a>
-            {{#if headings.length}}
-            <ul>
-                {{#each headings}}
-                <li class="page-heading"><a href="#{{id}}">{{text}}</a></li>
-                {{/each}}
-            </ul>
-            {{/if}}
+      {{#each docs}} {{#if (eq title ../title)}}
+      <li class="page">
+        <a href="#" class="page-title-active">{{title}}</a>
+        {{#if headings.length}}
+        <ul>
+          {{#each headings}}
+          <li class="page-heading">
+            <a href="#{{id}}">{{text}}</a>
+            {{/each}}
+        </ul>
+        {{/if}}
         </li>
         {{else}}
-        <li class="page"><a href="/docs/{{paths.name}}">{{title}}</a>
-        {{/if}}
-    {{/each}}
+        <li class="page">
+          <a href="/docs/{{paths.name}}">{{title}}</a>
+          {{/if}} {{/each}}
     </ul>
-</nav>
+  </nav>
 
-<div id="main" class="center">
+  <div id="main" class="center">
 
-<h2>{{title}}</h2>
-{{{contents}}}
+    <h2>{{title}}</h2>
+    {{{contents}}}
 
-    <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
-    href="http://hardmath123.github.io">Hardmath123</a> (<a
-    href="http://github.com/Hardmath123">Github</a>). You're welcome to
-    leave questions, comments, advice, or ideas as Github issues. And
-    feel free to fork nearley with your own experiments!<br/>
+    <div id="footer">
+      <p>nearley is MIT-licensed. It's maintained by
+        <a href="http://hardmath123.github.io">Hardmath123</a> (
+        <a href="http://github.com/Hardmath123">Github</a>). You're welcome to leave questions, comments, advice, or ideas as Github issues. And feel free to fork
+        nearley with your own experiments!
+        <br/>
 
-    <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
-    <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
-</div>
+        <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
+          <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo" />
+        </a>
+    </div>
+    {{#if isDemoPage}}
+    <script charset="utf-8" src="/lib/nearley.js"></script>
+    <script charset="utf-8" src="/examples/js/csscolor.js"></script>
+    <script type="text/javascript">
+      window.addEventListener('load', function () {
+        document.getElementById('parse-input').addEventListener('keyup', function () {
+          // $ ./bin/nearleyc.js examples/csscolor.ne -o examples/js/csscolor.js
+          var str = this.value;
+          var parser = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
+          try {
+            parser.feed(str);
+            document.getElementById('parse-output').innerHTML = JSON.stringify(parser.results, null, 2);
+            this.style.color = "#559";
+          } catch (e) {
+            document.getElementById('parse-output').innerHTML = "";
+            this.style.color = "red";
+          }
+        }, false);
+      }, false);
+    </script>
+    {{/if}}
 
-{{#if isDemoPage}}
-<script charset="utf-8" src="/lib/nearley.js"></script>
-<script charset="utf-8" src="/examples/js/csscolor.js"></script>
-<script type="text/javascript">
-window.addEventListener(
-  "load",
-  function() {
-    document.getElementById("user-content-sample-parse").innerHTML =
-      '<input type="text" id="parse-input" placeholder="rgba(0, 255, 0, 0.5)" />\n\
-<pre><code id="parse-output">…and the parsed output will appear here!</code></pre>';
-    document.getElementById("parse-input").addEventListener(
-      "keyup",
-      function() {
-        // $ ./bin/nearleyc.js examples/csscolor.ne -o examples/js/csscolor.js
-        var str = this.value;
-        var parser = new nearley.Parser(
-          grammar.ParserRules,
-          grammar.ParserStart
-        );
-        try {
-          parser.feed(str);
-          document.getElementById("parse-output").innerHTML = JSON.stringify(
-            parser.results,
-            null,
-            2
-          );
-          this.style.color = "#559";
-        } catch (e) {
-          document.getElementById("parse-output").innerHTML = "";
-          this.style.color = "red";
+    <script>
+      window.addEventListener('scroll', onScroll)
+      window.addEventListener('resize', onScroll)
+      var timeout
+      function onScroll(e) {
+        if (timeout) clearTimeout(timeout)
+        timeout = setTimeout(scrollEnd, 50)
+      }
+      function scrollEnd() {
+        var headings = document.querySelectorAll('h3')
+        var offset = 60
+        for (var i = headings.length; i--;) {
+          var h3 = headings[i]
+          if (h3.offsetTop < window.scrollY + offset) {
+            var cur = document.querySelector('.page-heading-active')
+            if (cur) cur.className = 'page-heading'
+            document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
+            return
+          }
         }
-      },
-      false
-    );
-  },
-  false
-);
-</script>
-{{/if}}
+      }
+    </script>
 
-<script>
-window.addEventListener("scroll", onScroll);
-window.addEventListener("resize", onScroll);
-
-var timeout;
-function onScroll(e) {
-  if (timeout) clearTimeout(timeout);
-  timeout = setTimeout(scrollEnd, 50);
-}
-
-function scrollEnd() {
-  var headings = document.querySelectorAll("h3");
-  var offset = 60;
-  for (var i = headings.length; i--; ) {
-    var h3 = headings[i];
-    if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector(".page-heading-active");
-      if (cur) cur.className = "page-heading";
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
-        "page-heading page-heading-active";
-      return;
-    }
-  }
-}
-</script>
-
-<script>
-(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
-</script>
+    <script>
+      (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-46120535-5', 'auto');
+      ga('send', 'pageview');
+    </script>

--- a/docs/make.js
+++ b/docs/make.js
@@ -1,14 +1,15 @@
-const fs = require("fs");
 
-const Metalsmith = require("metalsmith");
-const { default: markdown } = require("metalsmith-github-markdown");
-const layouts = require("metalsmith-layouts");
-const paths = require("metalsmith-paths");
-const cheerio = require("cheerio");
-const { extname } = require("path");
+const fs = require("fs")
 
-const Handlebars = require("handlebars");
-Handlebars.registerHelper("eq", (a, b) => a === b);
+const Metalsmith = require("metalsmith")
+const { default: markdown } = require("metalsmith-github-markdown")
+const layouts = require("metalsmith-layouts")
+const paths = require("metalsmith-paths")
+const cheerio = require("cheerio")
+const { extname } = require("path")
+
+const Handlebars = require("handlebars")
+Handlebars.registerHelper("eq", (a, b) => a === b)
 
 /*
 const debug = (files, metalsmith, done) => {
@@ -17,78 +18,74 @@ const debug = (files, metalsmith, done) => {
 */
 
 const docs = articles => (files, metalsmith, done) => {
-  setImmediate(done);
+  setImmediate(done)
   Object.assign(metalsmith.metadata(), {
     docs: articles.map(name => {
-      const f = files[name + ".md"];
-      f.isDoc = true;
-      return f;
+      const f = files[name + ".md"]
+      f.isDoc = true
+      return f
     })
-  });
-};
+  })
+}
+
+function headings(files, metalsmith, done) {
+  setImmediate(done)
+  Object.keys(files).forEach(function(file) {
+    if (".html" !== extname(file)) return
+    var data = files[file]
+    var contents = data.contents.toString()
+    var $ = cheerio.load(contents)
+    data.headings = []
+
+    $("h3").each(function() {
+      let id
+      $(this)
+        .find("a.anchor")
+        .attr("id", (i, attr) => (id = /user-content-(.*)/.exec(attr)[1]))
+        .remove()
+      $(this).attr("id", id)
+      data.headings.push({
+        id,
+        text: $(this).text()
+      })
+    })
+    data.contents = Buffer.from($.html())
+  })
+}
 
 Metalsmith(__dirname)
   .metadata({
     version: require("../package.json").version,
-    css: fs.readFileSync("../www/main.css", "utf-8")
+    css: fs.readFileSync("../www/main.css", "utf-8"),
   })
   .source("md/")
   .destination(".")
   .clean(false)
-  .use(
-    paths({
-      property: "paths"
-    })
-  )
-  .use(
-    docs([
-      "index",
-      "getting-started",
-      "grammar",
-      "parser",
-      "tokenizers",
-      "tooling",
-      "how-to-grammar-good",
-      "using-in-frontend",
-      "glossary"
-    ])
-  )
-  //.use(debug)
-  .use(
-    markdown({
-      // accessToken: "github oath token goes here if being rate-limited"
-    })
-  )
-  .use(function(files, metalsmith, done) {
-    setImmediate(done);
-    Object.keys(files).forEach(function(file) {
-      if (".html" != extname(file)) return;
-      var data = files[file];
-      var contents = data.contents.toString();
-      var $ = cheerio.load(contents);
-      data.headings = [];
+  .use(paths({
+    property: "paths",
+  }))
+  .use(docs([
 
-      $("h3").each(function() {
-        let id;
-        $(this)
-          .find("a.anchor")
-          .attr("id", (i, attr) => (id = /user-content-(.*)/.exec(attr)[1]))
-          .remove();
-        $(this).attr("id", id);
-        data.headings.push({
-          id,
-          text: $(this).text()
-        });
-      });
-      data.contents = Buffer.from($.html());
-    });
-  })
-  .use(
-    layouts({
-      engine: "handlebars",
-      default: "template.html"
-    })
-  )
+    "index",
+    "getting-started",
+    "grammar",
+    "parser",
+    "tokenizers",
+    "tooling",
+    "how-to-grammar-good",
+    "using-in-frontend",
+    "glossary",
+
+  ]))
+  //.use(debug)
+  .use(markdown({
+      // accessToken: "github oauth token goes here if being rate-limited"
+  }))
+  .use(headings)
+  .use(layouts({
+    engine: "handlebars",
+    default: "template.html",
+  }))
   .build(function(err) {
-    if (err) throw err;
-  });
+    if (err) throw err
+  })

--- a/docs/make.js
+++ b/docs/make.js
@@ -1,91 +1,57 @@
 
-const fs = require("fs")
+const fs = require('fs')
 
-const Metalsmith = require("metalsmith")
-const { default: markdown } = require("metalsmith-github-markdown")
-const layouts = require("metalsmith-layouts")
-const paths = require("metalsmith-paths")
-const cheerio = require("cheerio")
-const { extname } = require("path")
+const Metalsmith = require('metalsmith')
+const markdown = require('./markdown.js')
+const headings = require('metalsmith-headings')
+const layouts = require('metalsmith-layouts')
+const paths = require('metalsmith-paths')
 
-const Handlebars = require("handlebars")
-Handlebars.registerHelper("eq", (a, b) => a === b)
-
-/*
-const debug = (files, metalsmith, done) => {
-  setImmediate(done)
-}
-*/
+const Handlebars = require('handlebars')
+Handlebars.registerHelper('eq', (a, b) => a === b)
 
 const docs = articles => (files, metalsmith, done) => {
   setImmediate(done)
   Object.assign(metalsmith.metadata(), {
     docs: articles.map(name => {
-      const f = files[name + ".md"]
+      const f = files[name + '.md']
       f.isDoc = true
       return f
-    })
-  })
-}
-
-function headings(files, metalsmith, done) {
-  setImmediate(done)
-  Object.keys(files).forEach(function(file) {
-    if (".html" !== extname(file)) return
-    var data = files[file]
-    var contents = data.contents.toString()
-    var $ = cheerio.load(contents)
-    data.headings = []
-
-    $("h3").each(function() {
-      let id
-      $(this)
-        .find("a.anchor")
-        .attr("id", (i, attr) => (id = /user-content-(.*)/.exec(attr)[1]))
-        .remove()
-      $(this).attr("id", id)
-      data.headings.push({
-        id,
-        text: $(this).text()
-      })
-    })
-    data.contents = Buffer.from($.html())
+    }),
   })
 }
 
 Metalsmith(__dirname)
   .metadata({
-    version: require("../package.json").version,
-    css: fs.readFileSync("../www/main.css", "utf-8"),
+    version: require('../package.json').version,
+    css: fs.readFileSync('../www/main.css', 'utf-8'),
   })
-  .source("md/")
-  .destination(".")
+  .source('md/')
+  .destination('.')
   .clean(false)
   .use(paths({
-    property: "paths",
+    property: 'paths'
   }))
   .use(docs([
 
-    "index",
-    "getting-started",
-    "grammar",
-    "parser",
-    "tokenizers",
-    "tooling",
-    "how-to-grammar-good",
-    "using-in-frontend",
-    "glossary",
+    'index',
+    'getting-started',
+    'grammar',
+    'parser',
+    'tokenizers',
+    'tooling',
+    'how-to-grammar-good',
+    'using-in-frontend',
+    'glossary',
 
   ]))
   //.use(debug)
-  .use(markdown({
-      // accessToken: "github oauth token goes here if being rate-limited"
-  }))
-  .use(headings)
+  .use(markdown)
+  .use(headings('h3'))
   .use(layouts({
-    engine: "handlebars",
-    default: "template.html",
+    engine: 'handlebars',
+    default: 'template.html',
   }))
-  .build(function(err) {
-    if (err) throw err
+  .build(err => {
+    if (err) throw err;
   })

--- a/docs/make.js
+++ b/docs/make.js
@@ -1,14 +1,14 @@
+const fs = require("fs");
 
-const fs = require('fs')
+const Metalsmith = require("metalsmith");
+const { default: markdown } = require("metalsmith-github-markdown");
+const layouts = require("metalsmith-layouts");
+const paths = require("metalsmith-paths");
+const cheerio = require("cheerio");
+const { extname } = require("path");
 
-const Metalsmith = require('metalsmith')
-const markdown = require('metalsmith-markdown')
-const headings = require('metalsmith-headings')
-const layouts = require('metalsmith-layouts')
-const paths = require('metalsmith-paths')
-
-const Handlebars = require('handlebars')
-Handlebars.registerHelper('eq', (a, b) => a === b)
+const Handlebars = require("handlebars");
+Handlebars.registerHelper("eq", (a, b) => a === b);
 
 /*
 const debug = (files, metalsmith, done) => {
@@ -17,51 +17,78 @@ const debug = (files, metalsmith, done) => {
 */
 
 const docs = articles => (files, metalsmith, done) => {
-  setImmediate(done)
+  setImmediate(done);
   Object.assign(metalsmith.metadata(), {
     docs: articles.map(name => {
-      const f = files[name + '.md']
-      f.isDoc = true
-      return f
-    }),
-  })
-}
+      const f = files[name + ".md"];
+      f.isDoc = true;
+      return f;
+    })
+  });
+};
 
 Metalsmith(__dirname)
   .metadata({
-    version: require('../package.json').version,
-    css: fs.readFileSync('../www/main.css', 'utf-8'),
+    version: require("../package.json").version,
+    css: fs.readFileSync("../www/main.css", "utf-8")
   })
-  .source('md/')
-  .destination('.')
+  .source("md/")
+  .destination(".")
   .clean(false)
-  .use(paths({
-    property: 'paths'
-  }))
-  .use(docs([
-
-    'index',
-    'getting-started',
-    'grammar',
-    'parser',
-    'tokenizers',
-    'tooling',
-    'how-to-grammar-good',
-    'using-in-frontend',
-    'glossary',
-
-  ]))
+  .use(
+    paths({
+      property: "paths"
+    })
+  )
+  .use(
+    docs([
+      "index",
+      "getting-started",
+      "grammar",
+      "parser",
+      "tokenizers",
+      "tooling",
+      "how-to-grammar-good",
+      "using-in-frontend",
+      "glossary"
+    ])
+  )
   //.use(debug)
-  .use(markdown({
-    smartypants: true,
-    gfm: true,
-  }))
-  .use(headings('h3'))
-  .use(layouts({
-    engine: 'handlebars',
-    default: 'template.html',
-  }))
+  .use(
+    markdown({
+      // accessToken: "github oath token goes here if being rate-limited"
+    })
+  )
+  .use(function(files, metalsmith, done) {
+    setImmediate(done);
+    Object.keys(files).forEach(function(file) {
+      if (".html" != extname(file)) return;
+      var data = files[file];
+      var contents = data.contents.toString();
+      var $ = cheerio.load(contents);
+      data.headings = [];
+
+      $("h3").each(function() {
+        let id;
+        $(this)
+          .find("a.anchor")
+          .attr("id", (i, attr) => (id = /user-content-(.*)/.exec(attr)[1]))
+          .remove();
+        $(this).attr("id", id);
+        data.headings.push({
+          id,
+          text: $(this).text()
+        });
+      });
+      data.contents = Buffer.from($.html());
+    });
+  })
+  .use(
+    layouts({
+      engine: "handlebars",
+      default: "template.html"
+    })
+  )
   .build(function(err) {
     if (err) throw err;
-  })
-
+  });

--- a/docs/markdown.js
+++ b/docs/markdown.js
@@ -25,7 +25,7 @@ module.exports = plugin;
 function plugin(files, metalsmith, done) {
   Promise.all(
     Object.keys(files).map(file => {
-      let data = files[data];
+      let data = files[file];
       if (!isMarkdown(file)) return;
       const dir = dirname(file);
       let html = basename(file, extname(file)) + ".html";

--- a/docs/markdown.js
+++ b/docs/markdown.js
@@ -30,14 +30,17 @@ function plugin(files, metalsmith, done) {
       let html = basename(file, extname(file)) + ".html";
       if ("." != dir) html = dir + "/" + html;
 
-      marked(data.contents.toString(), options, (err, out) => {
-        if (err instanceof Error) return rej(err);
-        if (typeof err === "string") out = err;
+      return new Promise((res, rej) => {
+        marked(data.contents.toString(), options, (err, out) => {
+          if (err instanceof Error) return rej(err);
+          if (typeof err === "string") out = err;
 
-        data.contents = Buffer.from(out);
+          data.contents = Buffer.from(out);
 
-        delete files[file];
-        files[html] = data;
+          delete files[file];
+          files[html] = data;
+          res()
+        });
       });
     })
   ).then(() => {

--- a/docs/markdown.js
+++ b/docs/markdown.js
@@ -1,0 +1,49 @@
+const { basename, dirname, extname } = require("path");
+const marked = require("marked");
+const gfmSyntax = require("github-markdown-syntax");
+
+const isMarkdown = file => /\.md|\.markdown/.test(extname(file));
+
+const toHighlight = [];
+const highlight = (code, lang, cb) => {
+  const len = toHighlight.push({ code, lang, cb });
+  setImmediate(async () => {
+    if (len === toHighlight.length) {
+      const results = await gfmSyntax(toHighlight);
+      results.forEach((res, i) => {
+        toHighlight[i].cb(null, res);
+      });
+    }
+  });
+};
+
+const options = { gfm: true, smartypants: true, highlight };
+
+module.exports = plugin;
+
+function plugin(files, metalsmith, done) {
+  Promise.all(
+    Object.entries(files).map(async ([file, data]) => {
+      if (!isMarkdown(file)) return;
+      const dir = dirname(file);
+      let html = basename(file, extname(file)) + ".html";
+      if ("." != dir) html = dir + "/" + html;
+      
+      const str = await new Promise(res =>
+        marked(data.contents.toString(), options, (err, out) => {
+          if (err instanceof Error) return rej(err);
+          if (typeof err === "string") {
+            out = err;
+          }
+          res(out);
+        })
+      );
+      data.contents = Buffer.from(str);
+
+      delete files[file];
+      files[html] = data;
+    })
+  ).then(() => {
+    done();
+  });
+}

--- a/docs/markdown.js
+++ b/docs/markdown.js
@@ -24,7 +24,8 @@ module.exports = plugin;
 
 function plugin(files, metalsmith, done) {
   Promise.all(
-    Object.entries(files).map(([file, data]) => {
+    Object.keys(files).map(file => {
+      let data = files[data];
       if (!isMarkdown(file)) return;
       const dir = dirname(file);
       let html = basename(file, extname(file)) + ".html";
@@ -39,7 +40,7 @@ function plugin(files, metalsmith, done) {
 
           delete files[file];
           files[html] = data;
-          res()
+          res();
         });
       });
     })

--- a/docs/md/grammar.md
+++ b/docs/md/grammar.md
@@ -162,7 +162,9 @@ expression -> number "+" number # sum of two numbers
 You can use valid RegExp charsets in a rule (unless you're using a
 [tokenizer](tokenizers)):
 
-    not_a_letter -> [^a-zA-Z]
+```ne
+not_a_letter -> [^a-zA-Z]
+```
 
 The `.` character can be used to represent any character.
 
@@ -171,7 +173,9 @@ The `.` character can be used to represent any character.
 You can create case-insensitive string literals by adding an `i` after the
 string literal:
 
-    cow -> "cow"i # matches CoW, COW, and so on.
+```ne
+cow -> "cow"i # matches CoW, COW, and so on.
+```ne
 
 Note that if you are using a lexer, your lexer should use the `i` flag in its
 regexes instead. That is, if you are using a lexer, you should *not* use the

--- a/docs/md/how-to-grammar-good.md
+++ b/docs/md/how-to-grammar-good.md
@@ -34,7 +34,9 @@ file should describe a general outline, and tiny details (terminals for
 whitespace, literals etc.) should be at the bottom. For example, if you're
 writing a parser for Scheme, you would start with
 
-    Sourcefile -> (S-expression | Comment):*
+```ne
+Sourcefile -> (S-expression | Comment):*
+```ne
 
 and then fill out what `s-expression` and `comment` mean. Most of the time,
 rules defined higher in the file reference rules defined lower down, and rules
@@ -46,7 +48,9 @@ Give your nonterminals useful names--mostly nouns that describe the string it
 will match. By convention, we use `_` for optional whitespace and `__` for
 mandatory whitespace: it makes it easy to write rules like
 
-    "(" _ expression _ ")"
+```ne
+"(" _ expression _ ")"
+```
 
 You can explicitly mark a nonterminal as optional or repetitive by postfixing
 its name with `?` and `+` (respectively)--as in `statementlist+` or `comment?`.
@@ -60,7 +64,9 @@ semantically legible, contextually appropriate and (most importantly) easy.
 It's very easy to mess up and create an exponentially ambiguous monstrosity
 such as
 
-    lotsofletters -> "a" | lotsofletters lotsofletters
+```ne
+lotsofletters -> "a" | lotsofletters lotsofletters
+```
 
 ### Postprocess or dispose
 
@@ -90,7 +96,9 @@ issue.
 You were a good little student and you paid attention to your professors when
 they told you never to write grammars like:
 
-    a -> a "something"
+```ne
+a -> a "something"
+```ne
 
 because a naïve recursive-descent parser would bork in an infinite loop.
 Nearley, of course, is much better, so you don't have to worry about that. If
@@ -109,10 +117,12 @@ Here's how you do it: you start with your lowest-precedence operator and work
 your way up to your highest precedence ones. Each operator gets its own
 nonterminal:
 
-    math -> sum
-    sum -> sum ("+"|"-") product | product
-    product -> product ("*"|"/") exp | exp
-    exp -> number "^" exp | number # this is right associative!
+```ne
+math -> sum
+sum -> sum ("+"|"-") product | product
+product -> product ("*"|"/") exp | exp
+exp -> number "^" exp | number # this is right associative!
+```
 
 It should be pretty clear how this works, and how to extend it to different
 types of operators. The main thing is to be careful with your associativity

--- a/docs/md/index.md
+++ b/docs/md/index.md
@@ -57,7 +57,7 @@ Pick](https://github.com/npm/npm-collection-staff-picks).
 ### Features
 
 *  nearley is the first JS parser to use the **Earley** algorithm (insert your
-   own ‘early bird’ pun here). It also implements Joop Leo's optimizations for
+   own ‘earley bird’ pun here). It also implements Joop Leo's optimizations for
    right-recursion, making it effectively **linear-time** for LL(k) grammars.
 *  nearley lives happily in **node**, but doesn't mind the **browser**.
 *  nearley outputs **small** files. And its **expressive** DSL comes with

--- a/docs/md/index.md
+++ b/docs/md/index.md
@@ -46,8 +46,9 @@ Pick](https://github.com/npm/npm-collection-staff-picks).
    rgb  ( -29.889%,7,8172)
    #a40
    ```
-6. You try it! Type a CSS color here:
-   <div id="sample-parse" />
+6. You try it! Type a CSS color here: 
+   <input type="text" id="parse-input" placeholder="rgba(0, 255, 0, 0.5)" />
+   <pre><code id="parse-output">…and the parsed output will appear here!</code></pre>
 7. Create beautiful railroad diagrams to document your grammar formally.
    ```bash
    $ nearley-railroad csscolor.ne -o csscolor.html

--- a/docs/md/index.md
+++ b/docs/md/index.md
@@ -47,8 +47,7 @@ Pick](https://github.com/npm/npm-collection-staff-picks).
    #a40
    ```
 6. You try it! Type a CSS color here:
-   <input type="text" id="parse-input" placeholder="rgba(0, 255, 0, 0.5)" />
-   <pre><code id="parse-output">…and the parsed output will appear here!</code></pre>
+   <div id="sample-parse" />
 7. Create beautiful railroad diagrams to document your grammar formally.
    ```bash
    $ nearley-railroad csscolor.ne -o csscolor.html

--- a/docs/md/tokenizers.md
+++ b/docs/md/tokenizers.md
@@ -49,14 +49,14 @@ Here is an example of a simple grammar:
 
 ```coffeescript
 @{%
-const moo = require("moo");
+  const moo = require("moo");
 
-const lexer = moo.compile({
-  ws:     /[ \t]+/,
-  number: /[0-9]+/,
-  word: /[a-z]+/,
-  times:  /\*|x/
-});
+  const lexer = moo.compile({
+    ws:     /[ \t]+/,
+    number: /[0-9]+/,
+    word: /[a-z]+/,
+    times:  /\*|x/
+  });
 %}
 
 # Pass your lexer object using the @lexer option:

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -629,11 +629,6 @@
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
-    "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
-    },
     "metalsmith": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/metalsmith/-/metalsmith-2.3.0.tgz",
@@ -679,22 +674,6 @@
         "is-utf8": "0.2.1",
         "lodash.omit": "4.5.0",
         "multimatch": "2.1.0"
-      }
-    },
-    "metalsmith-markdown": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/metalsmith-markdown/-/metalsmith-markdown-0.2.1.tgz",
-      "integrity": "sha1-Gh/utsdtFUB7dScdqBUJ0Hky11M=",
-      "requires": {
-        "debug": "0.7.4",
-        "marked": "0.3.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
-        }
       }
     },
     "metalsmith-paths": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -4,10 +4,39 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+    },
     "@types/node": {
-      "version": "9.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.5.tgz",
-      "integrity": "sha512-NOLEgsT6UiDTjnWG5Hd2Mg25LRyz/oe8ql3wbjzgSFeRzRROhPmtlsvIrei4B46UjERF0td9SZ1ZXPLOdcrBHg=="
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.2.tgz",
+      "integrity": "sha512-9NfEUDp3tgRhmoxzTpTo+lq+KIVFxZahuRX0LHF/9IzKHaWuoWsIrrJ61zw5cnnlGINX8lqJzXYfQTOICS5Q+A=="
+    },
+    "CSSselect": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
+      "integrity": "sha1-+Kt+H4QYzmPNput713ioXX7EkrI=",
+      "requires": {
+        "CSSwhat": "0.4",
+        "domutils": "1.4"
+      },
+      "dependencies": {
+        "domutils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+          "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
+          "requires": {
+            "domelementtype": "1"
+          }
+        }
+      }
+    },
+    "CSSwhat": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
+      "integrity": "sha1-hn2g/zn3eGEyQsRM/qg/CqTr35s="
     },
     "absolute": {
       "version": "0.0.1",
@@ -19,9 +48,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -57,7 +86,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-differ": {
@@ -70,7 +99,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -87,23 +116,6 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-    },
-    "babel-plugin-transform-runtime": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
-      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.11.1"
-      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -125,8 +137,29 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "cacheable-request": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "requires": {
+        "clone-response": "1.0.2",
+        "get-stream": "3.0.0",
+        "http-cache-semantics": "3.8.1",
+        "keyv": "3.0.0",
+        "lowercase-keys": "1.0.0",
+        "normalize-url": "2.0.1",
+        "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+        }
       }
     },
     "camelcase": {
@@ -141,8 +174,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -150,11 +183,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "cheerio": {
@@ -162,12 +195,12 @@
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
       "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
       "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.9.2",
-        "lodash": "4.17.5",
-        "parse5": "3.0.3"
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
       }
     },
     "cliui": {
@@ -176,8 +209,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -193,6 +226,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
     },
     "co": {
       "version": "3.1.0",
@@ -212,9 +253,9 @@
       "resolved": "https://registry.npmjs.org/co-fs-extra/-/co-fs-extra-1.2.1.tgz",
       "integrity": "sha1-O2rXfPJhRTD2d7HPYmZPW6dWtyI=",
       "requires": {
-        "co-from-stream": "0.0.0",
-        "fs-extra": "0.26.7",
-        "thunkify-wrap": "1.0.4"
+        "co-from-stream": "~0.0.0",
+        "fs-extra": "~0.26.5",
+        "thunkify-wrap": "~1.0.4"
       }
     },
     "co-read": {
@@ -248,13 +289,8 @@
       "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.5.tgz",
       "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
       "requires": {
-        "bluebird": "3.5.0"
+        "bluebird": "^3.1.1"
       }
-    },
-    "core-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -272,10 +308,10 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "1.0.1"
+        "nth-check": "~1.0.1"
       }
     },
     "css-what": {
@@ -297,13 +333,26 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "optional": true
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "dom-serializer": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -319,11 +368,11 @@
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
     },
     "domhandler": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
-      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -331,9 +380,14 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "ecstatic": {
       "version": "2.2.1",
@@ -341,10 +395,10 @@
       "integrity": "sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ==",
       "dev": true,
       "requires": {
-        "he": "1.1.1",
-        "mime": "1.3.6",
-        "minimist": "1.2.0",
-        "url-join": "2.0.2"
+        "he": "^1.1.1",
+        "mime": "^1.2.11",
+        "minimist": "^1.1.0",
+        "url-join": "^2.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -359,14 +413,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/enable/-/enable-1.3.2.tgz",
       "integrity": "sha1-nrpoN9FtCYK1n4fYib91REPVKTE="
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.21"
-      }
     },
     "entities": {
       "version": "1.1.1",
@@ -399,7 +445,16 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "requires": {
-        "is-extendable": "0.1.1"
+        "is-extendable": "^0.1.0"
+      }
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-extra": {
@@ -407,11 +462,11 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
       "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs-readdir-recursive": {
@@ -424,17 +479,55 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    },
+    "github-markdown-syntax": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/github-markdown-syntax/-/github-markdown-syntax-0.1.1.tgz",
+      "integrity": "sha1-WpfuF6n0lWsQQ8zZrCdfltfpIBc=",
+      "requires": {
+        "cheerio": "^1.0.0-rc.2",
+        "got": "^8.3.0"
+      }
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "got": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-8.3.1.tgz",
+      "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
+      "requires": {
+        "@sindresorhus/is": "^0.7.0",
+        "cacheable-request": "^2.1.1",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "into-stream": "^3.1.0",
+        "is-retry-allowed": "^1.1.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "mimic-response": "^1.0.0",
+        "p-cancelable": "^0.4.0",
+        "p-timeout": "^2.0.1",
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1",
+        "timed-out": "^4.0.1",
+        "url-parse-lax": "^3.0.0",
+        "url-to-options": "^1.0.1"
       }
     },
     "graceful-fs": {
@@ -447,11 +540,11 @@
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.1.1.tgz",
       "integrity": "sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=",
       "requires": {
-        "ansi-red": "0.1.1",
-        "coffee-script": "1.12.7",
-        "extend-shallow": "2.0.1",
-        "js-yaml": "3.9.1",
-        "toml": "2.3.2"
+        "ansi-red": "^0.1.1",
+        "coffee-script": "^1.12.4",
+        "extend-shallow": "^2.0.1",
+        "js-yaml": "^3.8.1",
+        "toml": "^2.3.2"
       }
     },
     "handlebars": {
@@ -459,10 +552,10 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       }
     },
     "has-ansi": {
@@ -470,13 +563,26 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-generators": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-generators/-/has-generators-1.0.1.tgz",
       "integrity": "sha1-pqLlVIYBGUBILhPiyTeRxEms9Ek="
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "^1.4.1"
+      }
     },
     "he": {
       "version": "1.1.1",
@@ -489,13 +595,18 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
-        "domutils": "1.5.1",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
+    },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
     },
     "http-proxy": {
       "version": "1.16.2",
@@ -503,8 +614,8 @@
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
       }
     },
     "http-server": {
@@ -514,21 +625,13 @@
       "dev": true,
       "requires": {
         "colors": "1.0.3",
-        "corser": "2.0.1",
-        "ecstatic": "2.2.1",
-        "http-proxy": "1.16.2",
-        "opener": "1.4.3",
-        "optimist": "0.6.1",
-        "portfinder": "1.0.13",
-        "union": "0.4.6"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
-      "requires": {
-        "safer-buffer": "2.1.2"
+        "corser": "~2.0.0",
+        "ecstatic": "^2.0.0",
+        "http-proxy": "^1.8.1",
+        "opener": "~1.4.0",
+        "optimist": "0.6.x",
+        "portfinder": "^1.0.13",
+        "union": "~0.4.3"
       }
     },
     "inflight": {
@@ -536,14 +639,23 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "requires": {
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
+      }
     },
     "is": {
       "version": "3.2.1",
@@ -560,10 +672,20 @@
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
-    "is-stream": {
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+    },
+    "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -575,21 +697,43 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      }
+    },
     "js-yaml": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
       "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "keyv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "requires": {
+        "json-buffer": "3.0.0"
       }
     },
     "kind-of": {
@@ -597,7 +741,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -605,7 +749,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "lazy-cache": {
@@ -615,9 +759,9 @@
       "optional": true
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.omit": {
       "version": "4.5.0",
@@ -629,36 +773,109 @@
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
+    "marked": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
+    },
     "metalsmith": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/metalsmith/-/metalsmith-2.3.0.tgz",
       "integrity": "sha1-gzr7taKmOF4tmuPZNeOeM+rqUjE=",
       "requires": {
         "absolute": "0.0.1",
-        "chalk": "1.1.3",
-        "clone": "1.0.2",
-        "co-fs-extra": "1.2.1",
-        "commander": "2.11.0",
-        "gray-matter": "2.1.1",
-        "has-generators": "1.0.1",
-        "is": "3.2.1",
-        "is-utf8": "0.2.1",
-        "recursive-readdir": "2.2.1",
-        "rimraf": "2.6.1",
-        "stat-mode": "0.2.2",
-        "thunkify": "2.1.2",
+        "chalk": "^1.1.3",
+        "clone": "^1.0.2",
+        "co-fs-extra": "^1.2.1",
+        "commander": "^2.6.0",
+        "gray-matter": "^2.0.0",
+        "has-generators": "^1.0.1",
+        "is": "^3.1.0",
+        "is-utf8": "~0.2.0",
+        "recursive-readdir": "^2.1.0",
+        "rimraf": "^2.2.8",
+        "stat-mode": "^0.2.0",
+        "thunkify": "^2.1.2",
         "unyield": "0.0.1",
-        "ware": "1.3.0",
-        "win-fork": "1.1.1"
+        "ware": "^1.2.0",
+        "win-fork": "^1.1.1"
       }
     },
-    "metalsmith-github-markdown": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/metalsmith-github-markdown/-/metalsmith-github-markdown-1.0.1.tgz",
-      "integrity": "sha1-+4eyDUHwiySnI953EX33lS+p0M8=",
+    "metalsmith-headings": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/metalsmith-headings/-/metalsmith-headings-0.2.0.tgz",
+      "integrity": "sha1-ucTX4WCeN3tFhj1HrjmGG4bFBSk=",
       "requires": {
-        "babel-plugin-transform-runtime": "6.23.0",
-        "node-fetch": "1.7.3"
+        "cheerio": "^0.14.0"
+      },
+      "dependencies": {
+        "cheerio": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
+          "integrity": "sha1-IJZI1QGEbelc3KZEDziaf1wp3I8=",
+          "requires": {
+            "CSSselect": "~0.4.0",
+            "entities": "~1.0.0",
+            "htmlparser2": "~3.7.0",
+            "lodash": "~2.4.1"
+          }
+        },
+        "domhandler": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
+          "integrity": "sha1-Wd+dzSJ+gIs2Wuc+H2aErD2Ub8I=",
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "entities": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+          "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
+        },
+        "htmlparser2": {
+          "version": "3.7.3",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+          "integrity": "sha1-amTHdjfAjG8w7CqBV6UzM758sF4=",
+          "requires": {
+            "domelementtype": "1",
+            "domhandler": "2.2",
+            "domutils": "1.5",
+            "entities": "1.0",
+            "readable-stream": "1.1"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
       }
     },
     "metalsmith-layouts": {
@@ -666,14 +883,14 @@
       "resolved": "https://registry.npmjs.org/metalsmith-layouts/-/metalsmith-layouts-1.8.1.tgz",
       "integrity": "sha1-o2XTmTnZFGzf5R+t7n2HVXP8y9w=",
       "requires": {
-        "async": "1.5.2",
-        "consolidate": "0.14.5",
-        "debug": "2.6.8",
-        "extend": "3.0.1",
-        "fs-readdir-recursive": "1.0.0",
-        "is-utf8": "0.2.1",
-        "lodash.omit": "4.5.0",
-        "multimatch": "2.1.0"
+        "async": "^1.3.0",
+        "consolidate": "^0.14.0",
+        "debug": "^2.2.0",
+        "extend": "^3.0.0",
+        "fs-readdir-recursive": "^1.0.0",
+        "is-utf8": "^0.2.0",
+        "lodash.omit": "^4.0.2",
+        "multimatch": "^2.0.0"
       }
     },
     "metalsmith-paths": {
@@ -687,12 +904,17 @@
       "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
       "dev": true
     },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -727,19 +949,20 @@
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
       }
     },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+    "normalize-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
       }
     },
     "nth-check": {
@@ -747,15 +970,20 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "opener": {
@@ -769,8 +997,31 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "p-cancelable": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "parse5": {
@@ -778,7 +1029,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "requires": {
-        "@types/node": "9.6.5"
+        "@types/node": "*"
       }
     },
     "path-is-absolute": {
@@ -786,16 +1037,26 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
     "portfinder": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.8",
-        "mkdirp": "0.5.1"
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
       }
+    },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -808,18 +1069,28 @@
       "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
       "dev": true
     },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "recursive-readdir": {
@@ -835,15 +1106,10 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.0.0"
           }
         }
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -856,13 +1122,21 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -870,25 +1144,28 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
     },
     "source-map": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "sprintf-js": {
@@ -901,12 +1178,17 @@
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
       "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI="
     },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -914,7 +1196,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "supports-color": {
@@ -932,8 +1214,13 @@
       "resolved": "https://registry.npmjs.org/thunkify-wrap/-/thunkify-wrap-1.0.4.tgz",
       "integrity": "sha1-tSvlSN3+/aIOALWMYJZ2K0PdaIA=",
       "requires": {
-        "enable": "1.3.2"
+        "enable": "1"
       }
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "toml": {
       "version": "2.3.2",
@@ -946,9 +1233,9 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "optional": true,
       "requires": {
-        "source-map": "0.5.6",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -971,7 +1258,7 @@
       "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
       "dev": true,
       "requires": {
-        "qs": "2.3.3"
+        "qs": "~2.3.3"
       }
     },
     "unyield": {
@@ -979,7 +1266,7 @@
       "resolved": "https://registry.npmjs.org/unyield/-/unyield-0.0.1.tgz",
       "integrity": "sha1-FQ5l2kK/d0JEW5WKZOubhdHSsYA=",
       "requires": {
-        "co": "3.1.0"
+        "co": "~3.1.0"
       }
     },
     "url-join": {
@@ -987,6 +1274,19 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.2.tgz",
       "integrity": "sha1-wHJ1aWetJLi1nldBVRyqx49QuLc=",
       "dev": true
+    },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -998,7 +1298,7 @@
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "requires": {
-        "wrap-fn": "0.1.5"
+        "wrap-fn": "^0.1.0"
       }
     },
     "win-fork": {
@@ -1036,9 +1336,9 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     }

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -485,9 +485,9 @@
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "github-markdown-syntax": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/github-markdown-syntax/-/github-markdown-syntax-0.1.2.tgz",
-      "integrity": "sha1-YL270l0jwOF8GIhYeA/60aigHnE=",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/github-markdown-syntax/-/github-markdown-syntax-0.1.3.tgz",
+      "integrity": "sha1-Jcf1fy1P7QJZClASSBaliZP0jFI=",
       "requires": {
         "cheerio": "^1.0.0-rc.2",
         "got": "^8.3.0"
@@ -548,9 +548,9 @@
       }
     },
     "handlebars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "requires": {
         "async": "^1.4.0",
         "optimist": "^0.6.1",
@@ -663,9 +663,9 @@
       "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU="
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -1239,9 +1239,9 @@
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "optional": true
         }
       }

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -485,9 +485,9 @@
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "github-markdown-syntax": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/github-markdown-syntax/-/github-markdown-syntax-0.1.3.tgz",
-      "integrity": "sha1-Jcf1fy1P7QJZClASSBaliZP0jFI=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/github-markdown-syntax/-/github-markdown-syntax-0.1.4.tgz",
+      "integrity": "sha1-B0q9AqpQ0QfoEC+FML4/pJ++wx0=",
       "requires": {
         "cheerio": "^1.0.0-rc.2",
         "got": "^8.3.0"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -4,19 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "CSSselect": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
-      "integrity": "sha1-+Kt+H4QYzmPNput713ioXX7EkrI=",
-      "requires": {
-        "CSSwhat": "0.4.7",
-        "domutils": "1.4.3"
-      }
-    },
-    "CSSwhat": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
-      "integrity": "sha1-hn2g/zn3eGEyQsRM/qg/CqTr35s="
+    "@types/node": {
+      "version": "9.6.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.5.tgz",
+      "integrity": "sha512-NOLEgsT6UiDTjnWG5Hd2Mg25LRyz/oe8ql3wbjzgSFeRzRROhPmtlsvIrei4B46UjERF0td9SZ1ZXPLOdcrBHg=="
     },
     "absolute": {
       "version": "0.0.1",
@@ -97,6 +88,23 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.5",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -106,6 +114,11 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
       "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -145,14 +158,16 @@
       }
     },
     "cheerio": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
-      "integrity": "sha1-IJZI1QGEbelc3KZEDziaf1wp3I8=",
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
       "requires": {
-        "CSSselect": "0.4.1",
-        "entities": "1.0.0",
-        "htmlparser2": "3.7.3",
-        "lodash": "2.4.2"
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash": "4.17.5",
+        "parse5": "3.0.3"
       }
     },
     "cliui": {
@@ -236,6 +251,11 @@
         "bluebird": "3.5.0"
       }
     },
+    "core-js": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -246,6 +266,22 @@
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
       "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
       "dev": true
+    },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
+        "domutils": "1.5.1",
+        "nth-check": "1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
     },
     "debug": {
       "version": "2.6.8",
@@ -274,11 +310,6 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
-        },
-        "entities": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
         }
       }
     },
@@ -288,18 +319,19 @@
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
     },
     "domhandler": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
-      "integrity": "sha1-Wd+dzSJ+gIs2Wuc+H2aErD2Ub8I=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
       "requires": {
         "domelementtype": "1.3.0"
       }
     },
     "domutils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-      "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
+        "dom-serializer": "0.1.0",
         "domelementtype": "1.3.0"
       }
     },
@@ -328,10 +360,18 @@
       "resolved": "https://registry.npmjs.org/enable/-/enable-1.3.2.tgz",
       "integrity": "sha1-nrpoN9FtCYK1n4fYib91REPVKTE="
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.21"
+      }
+    },
     "entities": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -445,26 +485,16 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
-      "integrity": "sha1-amTHdjfAjG8w7CqBV6UzM758sF4=",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "requires": {
         "domelementtype": "1.3.0",
-        "domhandler": "2.2.1",
+        "domhandler": "2.4.1",
         "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
-      },
-      "dependencies": {
-        "domutils": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-          "requires": {
-            "dom-serializer": "0.1.0",
-            "domelementtype": "1.3.0"
-          }
-        }
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "http-proxy": {
@@ -491,6 +521,14 @@
         "optimist": "0.6.1",
         "portfinder": "1.0.13",
         "union": "0.4.6"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+      "requires": {
+        "safer-buffer": "2.1.2"
       }
     },
     "inflight": {
@@ -522,15 +560,20 @@
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "js-yaml": {
       "version": "3.9.1",
@@ -572,9 +615,9 @@
       "optional": true
     },
     "lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash.omit": {
       "version": "4.5.0",
@@ -614,12 +657,13 @@
         "win-fork": "1.1.1"
       }
     },
-    "metalsmith-headings": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-headings/-/metalsmith-headings-0.2.0.tgz",
-      "integrity": "sha1-ucTX4WCeN3tFhj1HrjmGG4bFBSk=",
+    "metalsmith-github-markdown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/metalsmith-github-markdown/-/metalsmith-github-markdown-1.0.1.tgz",
+      "integrity": "sha1-+4eyDUHwiySnI953EX33lS+p0M8=",
       "requires": {
-        "cheerio": "0.14.0"
+        "babel-plugin-transform-runtime": "6.23.0",
+        "node-fetch": "1.7.3"
       }
     },
     "metalsmith-layouts": {
@@ -710,6 +754,23 @@
         "minimatch": "3.0.4"
       }
     },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "nth-check": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "requires": {
+        "boolbase": "1.0.0"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -733,6 +794,14 @@
         "wordwrap": "0.0.3"
       }
     },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "requires": {
+        "@types/node": "9.6.5"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -749,6 +818,11 @@
         "mkdirp": "0.5.1"
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
     "qs": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
@@ -756,14 +830,17 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "recursive-readdir": {
@@ -783,6 +860,11 @@
           }
         }
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -812,6 +894,16 @@
         "glob": "7.1.2"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "source-map": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -831,9 +923,12 @@
       "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI="
     },
     "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -913,6 +1008,11 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.2.tgz",
       "integrity": "sha1-wHJ1aWetJLi1nldBVRyqx49QuLc=",
       "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "ware": {
       "version": "1.3.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -485,9 +485,9 @@
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "github-markdown-syntax": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/github-markdown-syntax/-/github-markdown-syntax-0.1.1.tgz",
-      "integrity": "sha1-WpfuF6n0lWsQQ8zZrCdfltfpIBc=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/github-markdown-syntax/-/github-markdown-syntax-0.1.2.tgz",
+      "integrity": "sha1-YL270l0jwOF8GIhYeA/60aigHnE=",
       "requires": {
         "cheerio": "^1.0.0-rc.2",
         "got": "^8.3.0"

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "start": "http-server ../"
   },
   "dependencies": {
-    "github-markdown-syntax": "^0.1.1",
+    "github-markdown-syntax": "^0.1.2",
     "handlebars": "^4.0.10",
     "marked": "^0.4.0",
     "metalsmith": "^2.3.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "start": "http-server ../"
   },
   "dependencies": {
-    "github-markdown-syntax": "^0.1.3",
+    "github-markdown-syntax": "^0.1.4",
     "handlebars": "^4.0.11",
     "marked": "^0.4.0",
     "metalsmith": "^2.3.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,8 +7,8 @@
     "start": "http-server ../"
   },
   "dependencies": {
-    "github-markdown-syntax": "^0.1.2",
-    "handlebars": "^4.0.10",
+    "github-markdown-syntax": "^0.1.3",
+    "handlebars": "^4.0.11",
     "marked": "^0.4.0",
     "metalsmith": "^2.3.0",
     "metalsmith-headings": "^0.2.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,6 @@
     "metalsmith": "^2.3.0",
     "metalsmith-github-markdown": "^1.0.1",
     "metalsmith-layouts": "^1.8.1",
-    "metalsmith-markdown": "^0.2.1",
     "metalsmith-paths": "^3.0.1"
   },
   "devDependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,9 +7,10 @@
     "start": "http-server ../"
   },
   "dependencies": {
+    "cheerio": "^1.0.0-rc.2",
     "handlebars": "^4.0.10",
     "metalsmith": "^2.3.0",
-    "metalsmith-headings": "^0.2.0",
+    "metalsmith-github-markdown": "^1.0.1",
     "metalsmith-layouts": "^1.8.1",
     "metalsmith-markdown": "^0.2.1",
     "metalsmith-paths": "^3.0.1"

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,10 +7,11 @@
     "start": "http-server ../"
   },
   "dependencies": {
-    "cheerio": "^1.0.0-rc.2",
+    "github-markdown-syntax": "^0.1.1",
     "handlebars": "^4.0.10",
+    "marked": "^0.4.0",
     "metalsmith": "^2.3.0",
-    "metalsmith-github-markdown": "^1.0.1",
+    "metalsmith-headings": "^0.2.0",
     "metalsmith-layouts": "^1.8.1",
     "metalsmith-paths": "^3.0.1"
   },

--- a/docs/parser.html
+++ b/docs/parser.html
@@ -241,8 +241,6 @@ nav ul a {
     }
 }
 
-/* highlight.js */
-
 .highlight pre {
   display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
 }
@@ -423,25 +421,5 @@ function scrollEnd() {
 </script>
 
 <script>
-(function(i, s, o, g, r, a, m) {
-  i["GoogleAnalyticsObject"] = r;
-  (i[r] =
-    i[r] ||
-    function() {
-      (i[r].q = i[r].q || []).push(arguments);
-    }),
-    (i[r].l = 1 * new Date());
-  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-  a.async = 1;
-  a.src = g;
-  m.parentNode.insertBefore(a, m);
-})(
-  window,
-  document,
-  "script",
-  "https://www.google-analytics.com/analytics.js",
-  "ga"
-);
-ga("create", "UA-46120535-5", "auto");
-ga("send", "pageview");
+(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
 </script>

--- a/docs/parser.html
+++ b/docs/parser.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <title>Using a parser - nearley.js - JS Parsing Toolkit</title>
-<meta charset="utf-8"/>
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
-@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
+  @import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -145,11 +145,23 @@ code {
 
 pre code, .highlight pre {
     border-radius: 0.5em;
-    padding: 0.5em;
+    margin: 5px;
+    padding: 10px;
     display: block;
     overflow: auto;
 }
 
+.highlight pre {
+    padding: 0;
+    margin: 0;
+    display: block;
+    overflow-x: auto;
+}
+
+pre > code > pre > code {
+    padding: 0;
+    margin: 0;
+}
 
 ol {
     counter-reset: tutorial-counter;
@@ -206,7 +218,7 @@ nav ul a {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 0.25em 0.5em; */
+    padding: 0.25em 0.5em;
 }
 .page {
     display: block;
@@ -241,124 +253,171 @@ nav ul a {
     }
 }
 
-.highlight pre {
-  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+code pre {
+    margin: 0;
 }
-
 </style>
 
-<body class="docs-page">
+<body class="docs-page" >
 
-<a href="https://github.com/kach/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-<nav id="nav">
-    <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">2.12.1</span></a></h1>
+  <a href="https://github.com/kach/nearley" class="github-corner">
+    <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg>
+  </a>
+  <style>
+    .github-corner:hover .octo-arm {
+      animation: octocat-wave 560ms ease-in-out
+    }
+
+    @keyframes octocat-wave {
+      0%,
+      100% {
+        transform: rotate(0)
+      }
+      20%,
+      60% {
+        transform: rotate(-25deg)
+      }
+      40%,
+      80% {
+        transform: rotate(10deg)
+      }
+    }
+
+    @media (max-width:500px) {
+      .github-corner:hover .octo-arm {
+        animation: none
+      }
+      .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out
+      }
+    }
+  </style>
+  <nav id="nav">
+    <h1>
+      <a href="/">nearley
+        <span style="color: #559;">.js</span>
+        <span id="version">2.12.1</span>
+      </a>
+    </h1>
     <ul>
-        <li class="page"><a href="/docs/index">Home</a>
-        <li class="page"><a href="/docs/getting-started">Getting started</a>
-        <li class="page"><a href="/docs/grammar">Writing a parser</a>
-        <li class="page">
-            <a href="#" class="page-title-active">Using a parser</a>
-            <ul>
-                <li class="page-heading"><a href="#a-note-on-ambiguity">
-A note on ambiguity</a></li>
-                <li class="page-heading"><a href="#catching-errors">
-Catching errors</a></li>
-                <li class="page-heading"><a href="#accessing-the-parse-table">
-Accessing the parse table</a></li>
-                <li class="page-heading"><a href="#using-preprocessors">
-Using preprocessors</a></li>
-                <li class="page-heading"><a href="#whats-next">
-What&#x27;s next?</a></li>
-            </ul>
+               <li class="page">
+          <a href="/docs/index">Home</a>
+                    <li class="page">
+          <a href="/docs/getting-started">Getting started</a>
+                    <li class="page">
+          <a href="/docs/grammar">Writing a parser</a>
+            
+      <li class="page">
+        <a href="#" class="page-title-active">Using a parser</a>
+        <ul>
+          <li class="page-heading">
+            <a href="#a-note-on-ambiguity">A note on ambiguity</a>
+          <li class="page-heading">
+            <a href="#catching-errors">Catching errors</a>
+          <li class="page-heading">
+            <a href="#accessing-the-parse-table">Accessing the parse table</a>
+          <li class="page-heading">
+            <a href="#using-preprocessors">Using preprocessors</a>
+          <li class="page-heading">
+            <a href="#what-s-next-">What’s next?</a>
+        </ul>
         </li>
-        <li class="page"><a href="/docs/tokenizers">Tokenizers</a>
-        <li class="page"><a href="/docs/tooling">Tooling</a>
-        <li class="page"><a href="/docs/how-to-grammar-good">How to grammar good</a>
-        <li class="page"><a href="/docs/using-in-frontend">Compiling in browsers</a>
-        <li class="page"><a href="/docs/glossary">Glossary</a>
+          <li class="page">
+          <a href="/docs/tokenizers">Tokenizers</a>
+                    <li class="page">
+          <a href="/docs/tooling">Tooling</a>
+                    <li class="page">
+          <a href="/docs/how-to-grammar-good">How to grammar good</a>
+                    <li class="page">
+          <a href="/docs/using-in-frontend">Compiling in browsers</a>
+                    <li class="page">
+          <a href="/docs/glossary">Glossary</a>
+           
     </ul>
-</nav>
+  </nav>
 
-<div id="main" class="center">
+  <div id="main" class="center">
 
-<h2>Using a parser</h2>
-<html><head></head><body><p>This section describes nearley&apos;s parser API.</p>
+    <h2>Using a parser</h2>
+    <p>This section describes nearley’s parser API.</p>
 <p>Once you have compiled a <code>grammar.ne</code> file to a <code>grammar.js</code> module, you can
 then use nearley to instantiate a <code>Parser</code> object.</p>
 <p>First, import nearley and your grammar.</p>
-<div class="highlight highlight-source-js"><pre><span class="pl-k">const</span> <span class="pl-c1">nearley</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley<span class="pl-pds">&quot;</span></span>);
-<span class="pl-k">const</span> <span class="pl-c1">grammar</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>./grammar.js<span class="pl-pds">&quot;</span></span>);</pre></div>
+<pre><code class="language-js"><div class="highlight highlight-source-js"><pre><span class="pl-k">const</span> <span class="pl-c1">nearley</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley<span class="pl-pds">&quot;</span></span>);
+<span class="pl-k">const</span> <span class="pl-c1">grammar</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>./grammar.js<span class="pl-pds">&quot;</span></span>);</pre></div></code></pre>
 <p>Note that if you are parsing in the browser, you can simply include
 <code>nearley.js</code> and <code>grammar.js</code> in <code>&lt;script&gt;</code> tags.</p>
 <p>Next, use the grammar to create a new <code>nearley.Parser</code> object.</p>
-<div class="highlight highlight-source-js"><pre><span class="pl-c"><span class="pl-c">//</span> Create a Parser object from our grammar.</span>
-<span class="pl-k">const</span> <span class="pl-c1">parser</span> <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">nearley.Parser</span>(<span class="pl-smi">nearley</span>.<span class="pl-smi">Grammar</span>.<span class="pl-en">fromCompiled</span>(grammar));</pre></div>
+<pre><code class="language-js"><div class="highlight highlight-source-js"><pre><span class="pl-c"><span class="pl-c">//</span> Create a Parser object from our grammar.</span>
+<span class="pl-k">const</span> <span class="pl-c1">parser</span> <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">nearley.Parser</span>(<span class="pl-smi">nearley</span>.<span class="pl-smi">Grammar</span>.<span class="pl-en">fromCompiled</span>(grammar));</pre></div></code></pre>
 <p>Once you have a <code>Parser</code>, you can <code>.feed</code> it a string to parse. Since nearley
 is a <em>streaming</em> parser, you can feed strings more than once. For example, a
 REPL might feed the parser lines of code as the user enters them:</p>
-<div class="highlight highlight-source-js"><pre><span class="pl-c"><span class="pl-c">//</span> Parse something!</span>
+<pre><code class="language-js"><div class="highlight highlight-source-js"><pre><span class="pl-c"><span class="pl-c">//</span> Parse something!</span>
 <span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>if (true) {<span class="pl-pds">&quot;</span></span>);
 <span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>x = 1<span class="pl-pds">&quot;</span></span>);
 <span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>}<span class="pl-pds">&quot;</span></span>);
-<span class="pl-c"><span class="pl-c">//</span> or, parser.feed(&quot;if (true) {x=1}&quot;);</span></pre></div>
+<span class="pl-c"><span class="pl-c">//</span> or, parser.feed(&quot;if (true) {x=1}&quot;);</span></pre></div></code></pre>
 <p>Finally, you can query the <code>.results</code> property of the parser.</p>
-<div class="highlight highlight-source-js"><pre><span class="pl-c"><span class="pl-c">//</span> parser.results is an array of possible parsings.</span>
+<pre><code class="language-js"><div class="highlight highlight-source-js"><pre><span class="pl-c"><span class="pl-c">//</span> parser.results is an array of possible parsings.</span>
 <span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-smi">parser</span>.<span class="pl-smi">results</span>);
-<span class="pl-c"><span class="pl-c">//</span> [{&apos;type&apos;: &apos;if&apos;, &apos;condition&apos;: ..., &apos;body&apos;: ...}]</span></pre></div>
-<h3 id="a-note-on-ambiguity">
-A note on ambiguity</h3>
+<span class="pl-c"><span class="pl-c">//</span> [{&apos;type&apos;: &apos;if&apos;, &apos;condition&apos;: ..., &apos;body&apos;: ...}]</span></pre></div></code></pre>
+<h3 id="a-note-on-ambiguity">A note on ambiguity</h3>
 <p>Why is <code>parser.results</code> an array? Sometimes, a grammar can parse a particular
 string in multiple different ways. For example, the following grammar parses
 the string <code>&quot;xyz&quot;</code> in two different ways.</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">x</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;xy&quot;</span> <span class="pl-s">&quot;z&quot;</span>
-   <span class="pl-k">|</span> <span class="pl-s">&quot;x&quot;</span> <span class="pl-s">&quot;yz&quot;</span></pre></div>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">x</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;xy&quot;</span> <span class="pl-s">&quot;z&quot;</span>
+   <span class="pl-k">|</span> <span class="pl-s">&quot;x&quot;</span> <span class="pl-s">&quot;yz&quot;</span></pre></div></code></pre>
 <p>Such grammars are <em>ambiguous</em>. nearley provides you with <em>all</em> the parsings. In
 most cases, however, your grammars should not be ambiguous (parsing ambiguous
 grammars is inefficient!). Thus, the most common usage is to simply query
 <code>parser.results[0]</code>.</p>
 <p>You might like to check first that <code>parser.results.length</code> is exactly 1; if
 there is more than one result, then your grammar is ambiguous!</p>
-<h3 id="catching-errors">
-Catching errors</h3>
+<h3 id="catching-errors">Catching errors</h3>
 <p>nearley is a <em>streaming</em> parser: you can call <code>feed()</code> as many times as you
 like. This means there are two ways parsing can go wrong.</p>
 <p>Consider the simple parser below for the examples to follow.</p>
-<div class="highlight highlight-source-js"><pre>main <span class="pl-k">-</span><span class="pl-k">&gt;</span> <span class="pl-s"><span class="pl-pds">&quot;</span>Cow goes moo.<span class="pl-pds">&quot;</span></span> {<span class="pl-k">%</span> <span class="pl-k">function</span>(<span class="pl-smi">d</span>) {<span class="pl-k">return</span> <span class="pl-s"><span class="pl-pds">&quot;</span>yay!<span class="pl-pds">&quot;</span></span>; } <span class="pl-k">%</span>}</pre></div>
+<pre><code class="language-js"><div class="highlight highlight-source-js"><pre>main <span class="pl-k">-</span><span class="pl-k">&gt;</span> <span class="pl-s"><span class="pl-pds">&quot;</span>Cow goes moo.<span class="pl-pds">&quot;</span></span> {<span class="pl-k">%</span> <span class="pl-k">function</span>(<span class="pl-smi">d</span>) {<span class="pl-k">return</span> <span class="pl-s"><span class="pl-pds">&quot;</span>yay!<span class="pl-pds">&quot;</span></span>; } <span class="pl-k">%</span>}</pre></div></code></pre>
 <p>If nearley gets <strong>partway through the chunk</strong> you fed, and parsing cannot
 continue, then nearley will throw an error whose <code>offset</code> property is the index
 of the offending token. There is no way to recover from this by feeding more
 data.</p>
-<div class="highlight highlight-source-js"><pre><span class="pl-k">try</span> {
+<pre><code class="language-js"><div class="highlight highlight-source-js"><pre><span class="pl-k">try</span> {
     <span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>Cow goes% moo.<span class="pl-pds">&quot;</span></span>);
 } <span class="pl-k">catch</span> (err) {
     <span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>Error at character <span class="pl-pds">&quot;</span></span> <span class="pl-k">+</span> <span class="pl-smi">parseError</span>.<span class="pl-smi">offset</span>); <span class="pl-c"><span class="pl-c">//</span> &quot;Error at character 9&quot;</span>
-}</pre></div>
+}</pre></div></code></pre>
 <p>Errors are nicely formatted for you:</p>
-<pre><code>Error: invalid syntax at line 1 col 9:
+<pre><code><pre><code>Error: invalid syntax at line 1 col 9:
 
   Cow goes% moo
           ^
 Unexpected &quot;%&quot;
-</code></pre>
-<p><strong>After <code>feed()</code> finishes</strong>, the <code>results</code> array will contain all possible
+</code></pre></code></pre><p><strong>After <code>feed()</code> finishes</strong>, the <code>results</code> array will contain all possible
 parsings.</p>
 <p>If there are no possible parsings given the current input, but in the <em>future</em>
 there <em>might</em> be results if you feed it more strings, then nearley will
 temporarily set the <code>results</code> array to the empty array, <code>[]</code>.</p>
-<div class="highlight highlight-source-js"><pre><span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>Cow <span class="pl-pds">&quot;</span></span>);  <span class="pl-c"><span class="pl-c">//</span> parser.results is []</span>
+<pre><code class="language-js"><div class="highlight highlight-source-js"><pre><span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>Cow <span class="pl-pds">&quot;</span></span>);  <span class="pl-c"><span class="pl-c">//</span> parser.results is []</span>
 <span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>goes <span class="pl-pds">&quot;</span></span>); <span class="pl-c"><span class="pl-c">//</span> parser.results is []</span>
-<span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>moo.<span class="pl-pds">&quot;</span></span>);  <span class="pl-c"><span class="pl-c">//</span> parser.results is [&quot;yay!&quot;]</span></pre></div>
-<p>If you&apos;re done calling <code>feed()</code>, but the array is still empty, this indicates
-&quot;unexpected end of input&quot;. Make sure to check there&apos;s at least one result.</p>
-<p>If there&apos;s more than one result, that indicates ambiguity--read on.</p>
-<h3 id="accessing-the-parse-table">
-Accessing the parse table</h3>
+<span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>moo.<span class="pl-pds">&quot;</span></span>);  <span class="pl-c"><span class="pl-c">//</span> parser.results is [&quot;yay!&quot;]</span></pre></div></code></pre>
+<p>If you’re done calling <code>feed()</code>, but the array is still empty, this indicates
+“unexpected end of input”. Make sure to check there’s at least one result.</p>
+<p>If there’s more than one result, that indicates ambiguity–read on.</p>
+<h3 id="accessing-the-parse-table">Accessing the parse table</h3>
 <p>If you are familiar with the Earley parsing algorithm, you can access the
 internal parse table using <code>Parser.table</code> (this, for example, is how
 <code>nearley-test</code> works). One caveat, however: you must pass the <code>keepHistory</code>
 option to nearley to prevent it from garbage-collecting inaccessible columns of
 the table.</p>
-<div class="highlight highlight-source-js"><pre><span class="pl-k">const</span> <span class="pl-c1">nearley</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley<span class="pl-pds">&quot;</span></span>);
+<pre><code class="language-js"><div class="highlight highlight-source-js"><pre><span class="pl-k">const</span> <span class="pl-c1">nearley</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley<span class="pl-pds">&quot;</span></span>);
 <span class="pl-k">const</span> <span class="pl-c1">grammar</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>./grammar<span class="pl-pds">&quot;</span></span>);
 
 <span class="pl-k">const</span> <span class="pl-c1">parser</span> <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">nearley.Parser</span>(
@@ -368,58 +427,61 @@ the table.</p>
 
 
 <span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-k">...</span>);
-<span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-smi">parser</span>.<span class="pl-smi">table</span>);</pre></div>
-<h3 id="using-preprocessors">
-Using preprocessors</h3>
+<span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-smi">parser</span>.<span class="pl-smi">table</span>);</pre></div></code></pre>
+<h3 id="using-preprocessors">Using preprocessors</h3>
 <p>By default, <code>nearleyc</code> compiles your grammar to JavaScript. However, you can
 instead choose to compile to CoffeeScript or TypeScript by adding
 <code>@preprocessor coffee</code> or <code>@preprocessor typescript</code> at the top of your grammar
 file. This can be useful to write your postprocessors in a different language,
 and to get type annotations if you wish to use nearley in a statically typed
 dialect of JavaScript.</p>
-<h3 id="whats-next">
-What&apos;s next?</h3>
+<h3 id="what-s-next-">What’s next?</h3>
 <p>Now that you know how to use parsers, <a href="tokenizers">learn how to add a tokenizer to speed
 things up!</a></p>
-</body></html>
-
-    <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
-    href="http://hardmath123.github.io">Hardmath123</a> (<a
-    href="http://github.com/Hardmath123">Github</a>). You're welcome to
-    leave questions, comments, advice, or ideas as Github issues. And
-    feel free to fork nearley with your own experiments!<br/>
-
-    <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
-    <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
-</div>
 
 
-<script>
-window.addEventListener("scroll", onScroll);
-window.addEventListener("resize", onScroll);
+    <div id="footer">
+      <p>nearley is MIT-licensed. It's maintained by
+        <a href="http://hardmath123.github.io">Hardmath123</a> (
+        <a href="http://github.com/Hardmath123">Github</a>). You're welcome to leave questions, comments, advice, or ideas as Github issues. And feel free to fork
+        nearley with your own experiments!
+        <br/>
 
-var timeout;
-function onScroll(e) {
-  if (timeout) clearTimeout(timeout);
-  timeout = setTimeout(scrollEnd, 50);
-}
+        <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
+          <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo" />
+        </a>
+    </div>
 
-function scrollEnd() {
-  var headings = document.querySelectorAll("h3");
-  var offset = 60;
-  for (var i = headings.length; i--; ) {
-    var h3 = headings[i];
-    if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector(".page-heading-active");
-      if (cur) cur.className = "page-heading";
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
-        "page-heading page-heading-active";
-      return;
-    }
-  }
-}
-</script>
+    <script>
+      window.addEventListener('scroll', onScroll)
+      window.addEventListener('resize', onScroll)
+      var timeout
+      function onScroll(e) {
+        if (timeout) clearTimeout(timeout)
+        timeout = setTimeout(scrollEnd, 50)
+      }
+      function scrollEnd() {
+        var headings = document.querySelectorAll('h3')
+        var offset = 60
+        for (var i = headings.length; i--;) {
+          var h3 = headings[i]
+          if (h3.offsetTop < window.scrollY + offset) {
+            var cur = document.querySelector('.page-heading-active')
+            if (cur) cur.className = 'page-heading'
+            document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
+            return
+          }
+        }
+      }
+    </script>
 
-<script>
-(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
-</script>
+    <script>
+      (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-46120535-5', 'auto');
+      ga('send', 'pageview');
+    </script>

--- a/docs/parser.html
+++ b/docs/parser.html
@@ -476,12 +476,12 @@ things up!</a></p>
     </script>
 
     <script>
-      (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-      ga('create', 'UA-46120535-5', 'auto');
-      ga('send', 'pageview');
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-46120535-5', 'auto');
+ga('send', 'pageview');
     </script>
+  </div>
+</body>

--- a/docs/parser.html
+++ b/docs/parser.html
@@ -4,6 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
+@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -142,7 +143,7 @@ code {
     background-color: #eee;
 }
 
-pre code {
+pre code, .highlight pre {
     border-radius: 0.5em;
     padding: 0.5em;
     display: block;
@@ -242,8 +243,9 @@ nav ul a {
 
 /* highlight.js */
 
-.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
-
+.highlight pre {
+  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+}
 
 </style>
 
@@ -259,11 +261,16 @@ nav ul a {
         <li class="page">
             <a href="#" class="page-title-active">Using a parser</a>
             <ul>
-                <li class="page-heading"><a href="#a-note-on-ambiguity">A note on ambiguity</a>
-                <li class="page-heading"><a href="#catching-errors">Catching errors</a>
-                <li class="page-heading"><a href="#accessing-the-parse-table">Accessing the parse table</a>
-                <li class="page-heading"><a href="#using-preprocessors">Using preprocessors</a>
-                <li class="page-heading"><a href="#what-s-next-">What’s next?</a>
+                <li class="page-heading"><a href="#a-note-on-ambiguity">
+A note on ambiguity</a></li>
+                <li class="page-heading"><a href="#catching-errors">
+Catching errors</a></li>
+                <li class="page-heading"><a href="#accessing-the-parse-table">
+Accessing the parse table</a></li>
+                <li class="page-heading"><a href="#using-preprocessors">
+Using preprocessors</a></li>
+                <li class="page-heading"><a href="#whats-next">
+What&#x27;s next?</a></li>
             </ul>
         </li>
         <li class="page"><a href="/docs/tokenizers">Tokenizers</a>
@@ -277,161 +284,164 @@ nav ul a {
 <div id="main" class="center">
 
 <h2>Using a parser</h2>
-<p>This section describes nearley’s parser API.</p>
+<html><head></head><body><p>This section describes nearley&apos;s parser API.</p>
 <p>Once you have compiled a <code>grammar.ne</code> file to a <code>grammar.js</code> module, you can
 then use nearley to instantiate a <code>Parser</code> object.</p>
 <p>First, import nearley and your grammar.</p>
-<pre><code class="lang-js">const nearley = require(&quot;nearley&quot;);
-const grammar = require(&quot;./grammar.js&quot;);
-</code></pre>
+<div class="highlight highlight-source-js"><pre><span class="pl-k">const</span> <span class="pl-c1">nearley</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley<span class="pl-pds">&quot;</span></span>);
+<span class="pl-k">const</span> <span class="pl-c1">grammar</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>./grammar.js<span class="pl-pds">&quot;</span></span>);</pre></div>
 <p>Note that if you are parsing in the browser, you can simply include
 <code>nearley.js</code> and <code>grammar.js</code> in <code>&lt;script&gt;</code> tags.</p>
 <p>Next, use the grammar to create a new <code>nearley.Parser</code> object.</p>
-<pre><code class="lang-js">// Create a Parser object from our grammar.
-const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
-</code></pre>
+<div class="highlight highlight-source-js"><pre><span class="pl-c"><span class="pl-c">//</span> Create a Parser object from our grammar.</span>
+<span class="pl-k">const</span> <span class="pl-c1">parser</span> <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">nearley.Parser</span>(<span class="pl-smi">nearley</span>.<span class="pl-smi">Grammar</span>.<span class="pl-en">fromCompiled</span>(grammar));</pre></div>
 <p>Once you have a <code>Parser</code>, you can <code>.feed</code> it a string to parse. Since nearley
 is a <em>streaming</em> parser, you can feed strings more than once. For example, a
 REPL might feed the parser lines of code as the user enters them:</p>
-<pre><code class="lang-js">// Parse something!
-parser.feed(&quot;if (true) {&quot;);
-parser.feed(&quot;x = 1&quot;);
-parser.feed(&quot;}&quot;);
-// or, parser.feed(&quot;if (true) {x=1}&quot;);
-</code></pre>
+<div class="highlight highlight-source-js"><pre><span class="pl-c"><span class="pl-c">//</span> Parse something!</span>
+<span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>if (true) {<span class="pl-pds">&quot;</span></span>);
+<span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>x = 1<span class="pl-pds">&quot;</span></span>);
+<span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>}<span class="pl-pds">&quot;</span></span>);
+<span class="pl-c"><span class="pl-c">//</span> or, parser.feed(&quot;if (true) {x=1}&quot;);</span></pre></div>
 <p>Finally, you can query the <code>.results</code> property of the parser.</p>
-<pre><code class="lang-js">// parser.results is an array of possible parsings.
-console.log(parser.results);
-// [{&#39;type&#39;: &#39;if&#39;, &#39;condition&#39;: ..., &#39;body&#39;: ...}]
-</code></pre>
-<h3 id="a-note-on-ambiguity">A note on ambiguity</h3>
+<div class="highlight highlight-source-js"><pre><span class="pl-c"><span class="pl-c">//</span> parser.results is an array of possible parsings.</span>
+<span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-smi">parser</span>.<span class="pl-smi">results</span>);
+<span class="pl-c"><span class="pl-c">//</span> [{&apos;type&apos;: &apos;if&apos;, &apos;condition&apos;: ..., &apos;body&apos;: ...}]</span></pre></div>
+<h3 id="a-note-on-ambiguity">
+A note on ambiguity</h3>
 <p>Why is <code>parser.results</code> an array? Sometimes, a grammar can parse a particular
 string in multiple different ways. For example, the following grammar parses
 the string <code>&quot;xyz&quot;</code> in two different ways.</p>
-<pre><code class="lang-ne">x -&gt; &quot;xy&quot; &quot;z&quot;
-   | &quot;x&quot; &quot;yz&quot;
-</code></pre>
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">x</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;xy&quot;</span> <span class="pl-s">&quot;z&quot;</span>
+   <span class="pl-k">|</span> <span class="pl-s">&quot;x&quot;</span> <span class="pl-s">&quot;yz&quot;</span></pre></div>
 <p>Such grammars are <em>ambiguous</em>. nearley provides you with <em>all</em> the parsings. In
 most cases, however, your grammars should not be ambiguous (parsing ambiguous
 grammars is inefficient!). Thus, the most common usage is to simply query
 <code>parser.results[0]</code>.</p>
 <p>You might like to check first that <code>parser.results.length</code> is exactly 1; if
 there is more than one result, then your grammar is ambiguous!</p>
-<h3 id="catching-errors">Catching errors</h3>
+<h3 id="catching-errors">
+Catching errors</h3>
 <p>nearley is a <em>streaming</em> parser: you can call <code>feed()</code> as many times as you
 like. This means there are two ways parsing can go wrong.</p>
 <p>Consider the simple parser below for the examples to follow.</p>
-<pre><code class="lang-js">main -&gt; &quot;Cow goes moo.&quot; {% function(d) {return &quot;yay!&quot;; } %}
-</code></pre>
+<div class="highlight highlight-source-js"><pre>main <span class="pl-k">-</span><span class="pl-k">&gt;</span> <span class="pl-s"><span class="pl-pds">&quot;</span>Cow goes moo.<span class="pl-pds">&quot;</span></span> {<span class="pl-k">%</span> <span class="pl-k">function</span>(<span class="pl-smi">d</span>) {<span class="pl-k">return</span> <span class="pl-s"><span class="pl-pds">&quot;</span>yay!<span class="pl-pds">&quot;</span></span>; } <span class="pl-k">%</span>}</pre></div>
 <p>If nearley gets <strong>partway through the chunk</strong> you fed, and parsing cannot
 continue, then nearley will throw an error whose <code>offset</code> property is the index
 of the offending token. There is no way to recover from this by feeding more
 data.</p>
-<pre><code class="lang-js">try {
-    parser.feed(&quot;Cow goes% moo.&quot;);
-} catch (err) {
-    console.log(&quot;Error at character &quot; + parseError.offset); // &quot;Error at character 9&quot;
-}
-</code></pre>
+<div class="highlight highlight-source-js"><pre><span class="pl-k">try</span> {
+    <span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>Cow goes% moo.<span class="pl-pds">&quot;</span></span>);
+} <span class="pl-k">catch</span> (err) {
+    <span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>Error at character <span class="pl-pds">&quot;</span></span> <span class="pl-k">+</span> <span class="pl-smi">parseError</span>.<span class="pl-smi">offset</span>); <span class="pl-c"><span class="pl-c">//</span> &quot;Error at character 9&quot;</span>
+}</pre></div>
 <p>Errors are nicely formatted for you:</p>
 <pre><code>Error: invalid syntax at line 1 col 9:
 
   Cow goes% moo
           ^
 Unexpected &quot;%&quot;
-</code></pre><p><strong>After <code>feed()</code> finishes</strong>, the <code>results</code> array will contain all possible
+</code></pre>
+<p><strong>After <code>feed()</code> finishes</strong>, the <code>results</code> array will contain all possible
 parsings.</p>
 <p>If there are no possible parsings given the current input, but in the <em>future</em>
 there <em>might</em> be results if you feed it more strings, then nearley will
 temporarily set the <code>results</code> array to the empty array, <code>[]</code>.</p>
-<pre><code class="lang-js">parser.feed(&quot;Cow &quot;);  // parser.results is []
-parser.feed(&quot;goes &quot;); // parser.results is []
-parser.feed(&quot;moo.&quot;);  // parser.results is [&quot;yay!&quot;]
-</code></pre>
-<p>If you’re done calling <code>feed()</code>, but the array is still empty, this indicates
-“unexpected end of input”. Make sure to check there’s at least one result.</p>
-<p>If there’s more than one result, that indicates ambiguity–read on.</p>
-<h3 id="accessing-the-parse-table">Accessing the parse table</h3>
+<div class="highlight highlight-source-js"><pre><span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>Cow <span class="pl-pds">&quot;</span></span>);  <span class="pl-c"><span class="pl-c">//</span> parser.results is []</span>
+<span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>goes <span class="pl-pds">&quot;</span></span>); <span class="pl-c"><span class="pl-c">//</span> parser.results is []</span>
+<span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>moo.<span class="pl-pds">&quot;</span></span>);  <span class="pl-c"><span class="pl-c">//</span> parser.results is [&quot;yay!&quot;]</span></pre></div>
+<p>If you&apos;re done calling <code>feed()</code>, but the array is still empty, this indicates
+&quot;unexpected end of input&quot;. Make sure to check there&apos;s at least one result.</p>
+<p>If there&apos;s more than one result, that indicates ambiguity--read on.</p>
+<h3 id="accessing-the-parse-table">
+Accessing the parse table</h3>
 <p>If you are familiar with the Earley parsing algorithm, you can access the
 internal parse table using <code>Parser.table</code> (this, for example, is how
 <code>nearley-test</code> works). One caveat, however: you must pass the <code>keepHistory</code>
 option to nearley to prevent it from garbage-collecting inaccessible columns of
 the table.</p>
-<pre><code class="lang-js">const nearley = require(&quot;nearley&quot;);
-const grammar = require(&quot;./grammar&quot;);
+<div class="highlight highlight-source-js"><pre><span class="pl-k">const</span> <span class="pl-c1">nearley</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley<span class="pl-pds">&quot;</span></span>);
+<span class="pl-k">const</span> <span class="pl-c1">grammar</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>./grammar<span class="pl-pds">&quot;</span></span>);
 
-const parser = new nearley.Parser(
-    nearley.Grammar.fromCompiled(grammar),
-    { keepHistory: true }
+<span class="pl-k">const</span> <span class="pl-c1">parser</span> <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">nearley.Parser</span>(
+    <span class="pl-smi">nearley</span>.<span class="pl-smi">Grammar</span>.<span class="pl-en">fromCompiled</span>(grammar),
+    { keepHistory<span class="pl-k">:</span> <span class="pl-c1">true</span> }
 );
 
 
-parser.feed(...);
-console.log(parser.table);
-</code></pre>
-<h3 id="using-preprocessors">Using preprocessors</h3>
+<span class="pl-smi">parser</span>.<span class="pl-en">feed</span>(<span class="pl-k">...</span>);
+<span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-smi">parser</span>.<span class="pl-smi">table</span>);</pre></div>
+<h3 id="using-preprocessors">
+Using preprocessors</h3>
 <p>By default, <code>nearleyc</code> compiles your grammar to JavaScript. However, you can
 instead choose to compile to CoffeeScript or TypeScript by adding
 <code>@preprocessor coffee</code> or <code>@preprocessor typescript</code> at the top of your grammar
 file. This can be useful to write your postprocessors in a different language,
 and to get type annotations if you wish to use nearley in a statically typed
 dialect of JavaScript.</p>
-<h3 id="what-s-next-">What’s next?</h3>
+<h3 id="whats-next">
+What&apos;s next?</h3>
 <p>Now that you know how to use parsers, <a href="tokenizers">learn how to add a tokenizer to speed
 things up!</a></p>
-
+</body></html>
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
     href="http://hardmath123.github.io">Hardmath123</a> (<a
     href="http://github.com/Hardmath123">Github</a>). You're welcome to
     leave questions, comments, advice, or ideas as Github issues. And
     feel free to fork nearley with your own experiments!<br/>
-    
+
     <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
     <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
 </div>
 
-<script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>
-document.querySelector('#highlight-js').addEventListener('load', function() {
-    [].slice.apply(document.querySelectorAll('pre code')).forEach(function(b) {
-        hljs.highlightBlock(b)
-    })
-})
-</script>
-
 
 <script>
-window.addEventListener('scroll', onScroll)
-window.addEventListener('resize', onScroll)
+window.addEventListener("scroll", onScroll);
+window.addEventListener("resize", onScroll);
 
-var timeout
+var timeout;
 function onScroll(e) {
-    if (timeout) clearTimeout(timeout)
-    timeout = setTimeout(scrollEnd, 50)
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(scrollEnd, 50);
 }
 
 function scrollEnd() {
-  var headings = document.querySelectorAll('h3')
-  var offset = 60
-  for (var i=headings.length; i--; ) {
-    var h3 = headings[i]
+  var headings = document.querySelectorAll("h3");
+  var offset = 60;
+  for (var i = headings.length; i--; ) {
+    var h3 = headings[i];
     if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector('.page-heading-active')
-      if (cur) cur.className = 'page-heading'
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
-      return
+      var cur = document.querySelector(".page-heading-active");
+      if (cur) cur.className = "page-heading";
+      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
+        "page-heading page-heading-active";
+      return;
     }
   }
 }
 </script>
 
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-46120535-5', 'auto');
-ga('send', 'pageview');
+(function(i, s, o, g, r, a, m) {
+  i["GoogleAnalyticsObject"] = r;
+  (i[r] =
+    i[r] ||
+    function() {
+      (i[r].q = i[r].q || []).push(arguments);
+    }),
+    (i[r].l = 1 * new Date());
+  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+  a.async = 1;
+  a.src = g;
+  m.parentNode.insertBefore(a, m);
+})(
+  window,
+  document,
+  "script",
+  "https://www.google-analytics.com/analytics.js",
+  "ga"
+);
+ga("create", "UA-46120535-5", "auto");
+ga("send", "pageview");
 </script>
-

--- a/docs/tokenizers.html
+++ b/docs/tokenizers.html
@@ -4,6 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
+@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -142,7 +143,7 @@ code {
     background-color: #eee;
 }
 
-pre code {
+pre code, .highlight pre {
     border-radius: 0.5em;
     padding: 0.5em;
     display: block;
@@ -242,8 +243,9 @@ nav ul a {
 
 /* highlight.js */
 
-.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
-
+.highlight pre {
+  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+}
 
 </style>
 
@@ -260,9 +262,12 @@ nav ul a {
         <li class="page">
             <a href="#" class="page-title-active">Tokenizers</a>
             <ul>
-                <li class="page-heading"><a href="#lexing-with-moo">Lexing with Moo</a>
-                <li class="page-heading"><a href="#custom-lexers">Custom lexers</a>
-                <li class="page-heading"><a href="#custom-token-matchers">Custom token matchers</a>
+                <li class="page-heading"><a href="#lexing-with-moo">
+Lexing with Moo</a></li>
+                <li class="page-heading"><a href="#custom-lexers">
+Custom lexers</a></li>
+                <li class="page-heading"><a href="#custom-token-matchers">
+Custom token matchers</a></li>
             </ul>
         </li>
         <li class="page"><a href="/docs/tooling">Tooling</a>
@@ -275,78 +280,84 @@ nav ul a {
 <div id="main" class="center">
 
 <h2>Tokenizers</h2>
-<p>By default, nearley splits the input into a stream of characters. This is
+<html><head></head><body><p>By default, nearley splits the input into a stream of characters. This is
 called <em>scannerless</em> parsing.</p>
 <p>A tokenizer splits the input into a stream of larger units called <em>tokens</em>.
 This happens in a separate stage before parsing. For example, a tokenizer might
 convert <code>512 + 10</code> into <code>[&quot;512&quot;, &quot;+&quot;, &quot;10&quot;]</code>: notice how it removed the
 whitespace, and combined multi-digit numbers into a single number.</p>
-<p>Using a tokenizer has many benefits. It…</p>
+<p>Using a tokenizer has many benefits. It...</p>
 <ul>
-<li>…often makes your parser faster by more than an order of magnitude.</li>
-<li>…allows you to write cleaner, more maintainable grammars.</li>
-<li>…helps avoid ambiguous grammars in some cases. For example, a tokenizer can
+<li>...often makes your parser faster by more than an order of magnitude.</li>
+<li>...allows you to write cleaner, more maintainable grammars.</li>
+<li>...helps avoid ambiguous grammars in some cases. For example, a tokenizer can
 easily tell you that <code>superclass</code> is a single keyword, not a sequence of
 <code>super</code> and <code>class</code> keywords.</li>
-<li>…gives you <em>lexical information</em> such as line numbers for each token. This
+<li>...gives you <em>lexical information</em> such as line numbers for each token. This
 lets you make better error messages.</li>
 </ul>
-<h3 id="lexing-with-moo">Lexing with Moo</h3>
-<p>The <code>@lexer</code> directive instructs Nearley to use a lexer you’ve defined inside a
+<h3 id="lexing-with-moo">
+Lexing with Moo</h3>
+<p>The <code>@lexer</code> directive instructs Nearley to use a lexer you&apos;ve defined inside a
 <a href="grammar#additional-js">Javascript block</a> in your grammar.</p>
 <p>nearley supports and recommends <a href="https://github.com/tjvr/moo">Moo</a>, a
 super-fast lexer. Construct a lexer using <code>moo.compile</code>.</p>
 <p>When using a lexer, there are two ways to match tokens:</p>
 <ul>
-<li><p>Use <code>%token</code> to match a token with <strong>type</strong> <code>token</code>.</p>
-<pre><code class="lang-ne">line -&gt; words %newline
-</code></pre>
+<li>
+<p>Use <code>%token</code> to match a token with <strong>type</strong> <code>token</code>.</p>
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">line</span> <span class="pl-k">-&gt;</span> <span class="pl-en">words</span> <span class="pl-k">%newline</span></pre></div>
 </li>
-<li><p>Use <code>&quot;foo&quot;</code> to match a token with <strong>text</strong> <code>foo</code>.</p>
+<li>
+<p>Use <code>&quot;foo&quot;</code> to match a token with <strong>text</strong> <code>foo</code>.</p>
 <p>This is convenient for matching keywords:</p>
-<pre><code class="lang-ne">ifStatement -&gt; &quot;if&quot; condition &quot;then&quot; block
-</code></pre>
+<div class="highlight highlight-source-ne"><pre><span class="pl-en">ifStatement</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;if&quot;</span> <span class="pl-en">condition</span> <span class="pl-s">&quot;then&quot;</span> <span class="pl-en">block</span></pre></div>
 </li>
 </ul>
 <p>Here is an example of a simple grammar:</p>
-<pre><code class="lang-coffeescript">@{%
-const moo = require(&quot;moo&quot;);
+<div class="highlight highlight-source-coffee"><pre><span class="pl-smi">@</span>{<span class="pl-k">%</span>
+<span class="pl-k">const</span> <span class="pl-v">moo</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>moo<span class="pl-pds">&quot;</span></span>);
 
-const lexer = moo.compile({
-  ws:     /[ \t]+/,
-  number: /[0-9]+/,
-  word: /[a-z]+/,
-  times:  /\*|x/
+<span class="pl-k">const</span> <span class="pl-v">lexer</span> <span class="pl-k">=</span> <span class="pl-smi">moo</span>.<span class="pl-c1">compile</span>({
+  <span class="pl-v">ws</span><span class="pl-k">:</span>     <span class="pl-sr"><span class="pl-pds">/</span><span class="pl-c1">[ <span class="pl-c1">\t</span>]</span><span class="pl-k">+</span><span class="pl-pds">/</span></span>,
+  <span class="pl-v">number</span><span class="pl-k">:</span> <span class="pl-sr"><span class="pl-pds">/</span><span class="pl-c1">[<span class="pl-c1">0-9</span>]</span><span class="pl-k">+</span><span class="pl-pds">/</span></span>,
+  <span class="pl-v">word</span><span class="pl-k">:</span> <span class="pl-sr"><span class="pl-pds">/</span><span class="pl-c1">[<span class="pl-c1">a-z</span>]</span><span class="pl-k">+</span><span class="pl-pds">/</span></span>,
+  <span class="pl-v">times</span><span class="pl-k">:</span>  <span class="pl-sr"><span class="pl-pds">/</span><span class="pl-cce">\*</span><span class="pl-k">|</span>x<span class="pl-pds">/</span></span>
 });
-%}
+<span class="pl-k">%</span>}
 
-# Pass your lexer object using the @lexer option:
-@lexer lexer
+<span class="pl-c"><span class="pl-c">#</span> Pass your lexer object using the @lexer option:</span>
+<span class="pl-smi">@</span><span class="pl-en">lexer</span> lexer
 
-# Use %token to match any token of that type instead of &quot;token&quot;:
-multiplication -&gt; %number %ws %times %ws %number {% ([first, , , , second]) =&gt; first * second %}
+<span class="pl-c"><span class="pl-c">#</span> Use %token to match any token of that type instead of &quot;token&quot;:</span>
+<span class="pl-en">multiplication</span> <span class="pl-k">-&gt;</span> <span class="pl-k">%</span>number <span class="pl-k">%</span>ws <span class="pl-k">%</span>times <span class="pl-k">%</span>ws <span class="pl-k">%</span><span class="pl-en">number</span> {<span class="pl-k">%</span> ([first, , , , second]) <span class="pl-k">=&gt;</span> first <span class="pl-k">*</span> second <span class="pl-k">%</span>}
 
-# Literal strings now match tokens with that text:
-trig -&gt; &quot;sin&quot; %number
-</code></pre>
+<span class="pl-c"><span class="pl-c">#</span> Literal strings now match tokens with that text:</span>
+<span class="pl-en">trig</span> <span class="pl-k">-&gt;</span> <span class="pl-s"><span class="pl-pds">&quot;</span>sin<span class="pl-pds">&quot;</span></span> <span class="pl-k">%</span>number</pre></div>
 <p>Have a look at <a href="https://github.com/tjvr/moo#usage">the Moo documentation</a> to
 learn more about writing a tokenizer.</p>
 <p>You use the parser as usual: call <code>parser.feed(data)</code>, and nearley will give
 you the parsed results in return.</p>
-<h3 id="custom-lexers">Custom lexers</h3>
+<h3 id="custom-lexers">
+Custom lexers</h3>
 <p>nearley recommends using a <a href="https://github.com/tjvr/moo">moo</a>-based lexer.
 However, you can use any lexer that conforms to the following interface:</p>
 <ul>
-<li><code>next()</code> returns a token object, which could have fields for line number,
+<li>
+<code>next()</code> returns a token object, which could have fields for line number,
 etc. Importantly, a token object <em>must</em> have a <code>value</code> attribute.</li>
-<li><code>save()</code> returns an info object that describes the current state of the
+<li>
+<code>save()</code> returns an info object that describes the current state of the
 lexer. nearley places no restrictions on this object.</li>
-<li><code>reset(chunk, info)</code> sets the internal buffer of the lexer to <code>chunk</code>, and
+<li>
+<code>reset(chunk, info)</code> sets the internal buffer of the lexer to <code>chunk</code>, and
 restores its state to a state returned by <code>save()</code>.</li>
-<li><code>formatError(token)</code> returns a string with an error message describing a
+<li>
+<code>formatError(token)</code> returns a string with an error message describing a
 parse error at that token (for example, the string might contain the line and
 column where the error was found).</li>
-<li><code>has(name)</code> returns true if the lexer can emit tokens with that name. This is
+<li>
+<code>has(name)</code> returns true if the lexer can emit tokens with that name. This is
 used to resolve <code>%</code>-specifiers in compiled nearley grammars.</li>
 </ul>
 <blockquote>
@@ -354,7 +365,8 @@ used to resolve <code>%</code>-specifiers in compiled nearley grammars.</li>
 grammars (like in Python), you can still use moo. See <a href="https://gist.github.com/nathan/d8d1adea38a1ef3a6d6a06552da641aa">this
 example</a></p>
 </blockquote>
-<h3 id="custom-token-matchers">Custom token matchers</h3>
+<h3 id="custom-token-matchers">
+Custom token matchers</h3>
 <p>Aside from the lexer infrastructure, nearley provides a lightweight way to
 parse arbitrary streams.</p>
 <p>Custom matchers can be defined in two ways: <em>literal</em> tokens and <em>testable</em>
@@ -362,68 +374,73 @@ tokens. A literal token matches a JS value exactly (with <code>===</code>), whil
 testable token runs a predicate that tests whether or not the value matches.</p>
 <p>Note that in this case, you would feed a <code>Parser</code> instance an <em>array</em> of
 objects rather than a string! Here is a simple example:</p>
-<pre><code class="lang-ne">@{%
-const tokenPrint = { literal: &quot;print&quot; };
-const tokenNumber = { test: x =&gt; Number.isInteger(x) };
-%}
+<div class="highlight highlight-source-ne"><pre><span class="pl-c">@{%</span>
+<span class="pl-k">const</span> <span class="pl-c1">tokenPrint</span> <span class="pl-k">=</span> { literal<span class="pl-k">:</span> <span class="pl-s"><span class="pl-pds">&quot;</span>print<span class="pl-pds">&quot;</span></span> };
+<span class="pl-k">const</span> <span class="pl-c1">tokenNumber</span> <span class="pl-k">=</span> { <span class="pl-en">test</span><span class="pl-k">:</span> <span class="pl-smi">x</span> <span class="pl-k">=&gt;</span> <span class="pl-c1">Number</span>.<span class="pl-en">isInteger</span>(x) };
+<span class="pl-c">%}</span>
 
-main -&gt; %tokenPrint %tokenNumber &quot;;;&quot;
+<span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-k">%tokenPrint</span> <span class="pl-k">%tokenNumber</span> <span class="pl-s">&quot;;;&quot;</span>
 
-# parser.feed([&quot;print&quot;, 12, &quot;;;&quot;]);
-</code></pre>
-
+<span class="pl-c"># parser.feed([&quot;print&quot;, 12, &quot;;;&quot;]);</span></pre></div>
+</body></html>
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
     href="http://hardmath123.github.io">Hardmath123</a> (<a
     href="http://github.com/Hardmath123">Github</a>). You're welcome to
     leave questions, comments, advice, or ideas as Github issues. And
     feel free to fork nearley with your own experiments!<br/>
-    
+
     <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
     <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
 </div>
 
-<script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>
-document.querySelector('#highlight-js').addEventListener('load', function() {
-    [].slice.apply(document.querySelectorAll('pre code')).forEach(function(b) {
-        hljs.highlightBlock(b)
-    })
-})
-</script>
-
 
 <script>
-window.addEventListener('scroll', onScroll)
-window.addEventListener('resize', onScroll)
+window.addEventListener("scroll", onScroll);
+window.addEventListener("resize", onScroll);
 
-var timeout
+var timeout;
 function onScroll(e) {
-    if (timeout) clearTimeout(timeout)
-    timeout = setTimeout(scrollEnd, 50)
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(scrollEnd, 50);
 }
 
 function scrollEnd() {
-  var headings = document.querySelectorAll('h3')
-  var offset = 60
-  for (var i=headings.length; i--; ) {
-    var h3 = headings[i]
+  var headings = document.querySelectorAll("h3");
+  var offset = 60;
+  for (var i = headings.length; i--; ) {
+    var h3 = headings[i];
     if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector('.page-heading-active')
-      if (cur) cur.className = 'page-heading'
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
-      return
+      var cur = document.querySelector(".page-heading-active");
+      if (cur) cur.className = "page-heading";
+      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
+        "page-heading page-heading-active";
+      return;
     }
   }
 }
 </script>
 
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-46120535-5', 'auto');
-ga('send', 'pageview');
+(function(i, s, o, g, r, a, m) {
+  i["GoogleAnalyticsObject"] = r;
+  (i[r] =
+    i[r] ||
+    function() {
+      (i[r].q = i[r].q || []).push(arguments);
+    }),
+    (i[r].l = 1 * new Date());
+  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+  a.async = 1;
+  a.src = g;
+  m.parentNode.insertBefore(a, m);
+})(
+  window,
+  document,
+  "script",
+  "https://www.google-analytics.com/analytics.js",
+  "ga"
+);
+ga("create", "UA-46120535-5", "auto");
+ga("send", "pageview");
 </script>
-

--- a/docs/tokenizers.html
+++ b/docs/tokenizers.html
@@ -471,12 +471,12 @@ objects rather than a string! Here is a simple example:</p>
     </script>
 
     <script>
-      (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-      ga('create', 'UA-46120535-5', 'auto');
-      ga('send', 'pageview');
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-46120535-5', 'auto');
+ga('send', 'pageview');
     </script>
+  </div>
+</body>

--- a/docs/tokenizers.html
+++ b/docs/tokenizers.html
@@ -374,14 +374,14 @@ super-fast lexer. Construct a lexer using <code>moo.compile</code>.</p>
 </ul>
 <p>Here is an example of a simple grammar:</p>
 <pre><code class="language-coffeescript"><div class="highlight highlight-source-coffee"><pre><span class="pl-smi">@</span>{<span class="pl-k">%</span>
-<span class="pl-k">const</span> <span class="pl-v">moo</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>moo<span class="pl-pds">&quot;</span></span>);
+  <span class="pl-k">const</span> <span class="pl-v">moo</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>moo<span class="pl-pds">&quot;</span></span>);
 
-<span class="pl-k">const</span> <span class="pl-v">lexer</span> <span class="pl-k">=</span> <span class="pl-smi">moo</span>.<span class="pl-c1">compile</span>({
-  <span class="pl-v">ws</span><span class="pl-k">:</span>     <span class="pl-sr"><span class="pl-pds">/</span><span class="pl-c1">[ <span class="pl-c1">\t</span>]</span><span class="pl-k">+</span><span class="pl-pds">/</span></span>,
-  <span class="pl-v">number</span><span class="pl-k">:</span> <span class="pl-sr"><span class="pl-pds">/</span><span class="pl-c1">[<span class="pl-c1">0-9</span>]</span><span class="pl-k">+</span><span class="pl-pds">/</span></span>,
-  <span class="pl-v">word</span><span class="pl-k">:</span> <span class="pl-sr"><span class="pl-pds">/</span><span class="pl-c1">[<span class="pl-c1">a-z</span>]</span><span class="pl-k">+</span><span class="pl-pds">/</span></span>,
-  <span class="pl-v">times</span><span class="pl-k">:</span>  <span class="pl-sr"><span class="pl-pds">/</span><span class="pl-cce">\*</span><span class="pl-k">|</span>x<span class="pl-pds">/</span></span>
-});
+  <span class="pl-k">const</span> <span class="pl-v">lexer</span> <span class="pl-k">=</span> <span class="pl-smi">moo</span>.<span class="pl-c1">compile</span>({
+    <span class="pl-v">ws</span><span class="pl-k">:</span>     <span class="pl-sr"><span class="pl-pds">/</span><span class="pl-c1">[ <span class="pl-c1">\t</span>]</span><span class="pl-k">+</span><span class="pl-pds">/</span></span>,
+    <span class="pl-v">number</span><span class="pl-k">:</span> <span class="pl-sr"><span class="pl-pds">/</span><span class="pl-c1">[<span class="pl-c1">0-9</span>]</span><span class="pl-k">+</span><span class="pl-pds">/</span></span>,
+    <span class="pl-v">word</span><span class="pl-k">:</span> <span class="pl-sr"><span class="pl-pds">/</span><span class="pl-c1">[<span class="pl-c1">a-z</span>]</span><span class="pl-k">+</span><span class="pl-pds">/</span></span>,
+    <span class="pl-v">times</span><span class="pl-k">:</span>  <span class="pl-sr"><span class="pl-pds">/</span><span class="pl-cce">\*</span><span class="pl-k">|</span>x<span class="pl-pds">/</span></span>
+  });
 <span class="pl-k">%</span>}
 
 <span class="pl-c"><span class="pl-c">#</span> Pass your lexer object using the @lexer option:</span>

--- a/docs/tokenizers.html
+++ b/docs/tokenizers.html
@@ -241,8 +241,6 @@ nav ul a {
     }
 }
 
-/* highlight.js */
-
 .highlight pre {
   display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
 }
@@ -422,25 +420,5 @@ function scrollEnd() {
 </script>
 
 <script>
-(function(i, s, o, g, r, a, m) {
-  i["GoogleAnalyticsObject"] = r;
-  (i[r] =
-    i[r] ||
-    function() {
-      (i[r].q = i[r].q || []).push(arguments);
-    }),
-    (i[r].l = 1 * new Date());
-  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-  a.async = 1;
-  a.src = g;
-  m.parentNode.insertBefore(a, m);
-})(
-  window,
-  document,
-  "script",
-  "https://www.google-analytics.com/analytics.js",
-  "ga"
-);
-ga("create", "UA-46120535-5", "auto");
-ga("send", "pageview");
+(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
 </script>

--- a/docs/tokenizers.html
+++ b/docs/tokenizers.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <title>Tokenizers - nearley.js - JS Parsing Toolkit</title>
-<meta charset="utf-8"/>
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
-@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
+  @import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -145,11 +145,23 @@ code {
 
 pre code, .highlight pre {
     border-radius: 0.5em;
-    padding: 0.5em;
+    margin: 5px;
+    padding: 10px;
     display: block;
     overflow: auto;
 }
 
+.highlight pre {
+    padding: 0;
+    margin: 0;
+    display: block;
+    overflow-x: auto;
+}
+
+pre > code > pre > code {
+    padding: 0;
+    margin: 0;
+}
 
 ol {
     counter-reset: tutorial-counter;
@@ -206,7 +218,7 @@ nav ul a {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 0.25em 0.5em; */
+    padding: 0.25em 0.5em;
 }
 .page {
     display: block;
@@ -241,79 +253,127 @@ nav ul a {
     }
 }
 
-.highlight pre {
-  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+code pre {
+    margin: 0;
 }
-
 </style>
 
-<body class="docs-page">
+<body class="docs-page" >
 
-<a href="https://github.com/kach/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-<nav id="nav">
-    <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">2.12.1</span></a></h1>
+  <a href="https://github.com/kach/nearley" class="github-corner">
+    <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg>
+  </a>
+  <style>
+    .github-corner:hover .octo-arm {
+      animation: octocat-wave 560ms ease-in-out
+    }
+
+    @keyframes octocat-wave {
+      0%,
+      100% {
+        transform: rotate(0)
+      }
+      20%,
+      60% {
+        transform: rotate(-25deg)
+      }
+      40%,
+      80% {
+        transform: rotate(10deg)
+      }
+    }
+
+    @media (max-width:500px) {
+      .github-corner:hover .octo-arm {
+        animation: none
+      }
+      .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out
+      }
+    }
+  </style>
+  <nav id="nav">
+    <h1>
+      <a href="/">nearley
+        <span style="color: #559;">.js</span>
+        <span id="version">2.12.1</span>
+      </a>
+    </h1>
     <ul>
-        <li class="page"><a href="/docs/index">Home</a>
-        <li class="page"><a href="/docs/getting-started">Getting started</a>
-        <li class="page"><a href="/docs/grammar">Writing a parser</a>
-        <li class="page"><a href="/docs/parser">Using a parser</a>
-        <li class="page">
-            <a href="#" class="page-title-active">Tokenizers</a>
-            <ul>
-                <li class="page-heading"><a href="#lexing-with-moo">
-Lexing with Moo</a></li>
-                <li class="page-heading"><a href="#custom-lexers">
-Custom lexers</a></li>
-                <li class="page-heading"><a href="#custom-token-matchers">
-Custom token matchers</a></li>
-            </ul>
+               <li class="page">
+          <a href="/docs/index">Home</a>
+                    <li class="page">
+          <a href="/docs/getting-started">Getting started</a>
+                    <li class="page">
+          <a href="/docs/grammar">Writing a parser</a>
+                    <li class="page">
+          <a href="/docs/parser">Using a parser</a>
+            
+      <li class="page">
+        <a href="#" class="page-title-active">Tokenizers</a>
+        <ul>
+          <li class="page-heading">
+            <a href="#lexing-with-moo">Lexing with Moo</a>
+          <li class="page-heading">
+            <a href="#custom-lexers">Custom lexers</a>
+          <li class="page-heading">
+            <a href="#custom-token-matchers">Custom token matchers</a>
+        </ul>
         </li>
-        <li class="page"><a href="/docs/tooling">Tooling</a>
-        <li class="page"><a href="/docs/how-to-grammar-good">How to grammar good</a>
-        <li class="page"><a href="/docs/using-in-frontend">Compiling in browsers</a>
-        <li class="page"><a href="/docs/glossary">Glossary</a>
+          <li class="page">
+          <a href="/docs/tooling">Tooling</a>
+                    <li class="page">
+          <a href="/docs/how-to-grammar-good">How to grammar good</a>
+                    <li class="page">
+          <a href="/docs/using-in-frontend">Compiling in browsers</a>
+                    <li class="page">
+          <a href="/docs/glossary">Glossary</a>
+           
     </ul>
-</nav>
+  </nav>
 
-<div id="main" class="center">
+  <div id="main" class="center">
 
-<h2>Tokenizers</h2>
-<html><head></head><body><p>By default, nearley splits the input into a stream of characters. This is
+    <h2>Tokenizers</h2>
+    <p>By default, nearley splits the input into a stream of characters. This is
 called <em>scannerless</em> parsing.</p>
 <p>A tokenizer splits the input into a stream of larger units called <em>tokens</em>.
 This happens in a separate stage before parsing. For example, a tokenizer might
 convert <code>512 + 10</code> into <code>[&quot;512&quot;, &quot;+&quot;, &quot;10&quot;]</code>: notice how it removed the
 whitespace, and combined multi-digit numbers into a single number.</p>
-<p>Using a tokenizer has many benefits. It...</p>
+<p>Using a tokenizer has many benefits. It…</p>
 <ul>
-<li>...often makes your parser faster by more than an order of magnitude.</li>
-<li>...allows you to write cleaner, more maintainable grammars.</li>
-<li>...helps avoid ambiguous grammars in some cases. For example, a tokenizer can
+<li>…often makes your parser faster by more than an order of magnitude.</li>
+<li>…allows you to write cleaner, more maintainable grammars.</li>
+<li>…helps avoid ambiguous grammars in some cases. For example, a tokenizer can
 easily tell you that <code>superclass</code> is a single keyword, not a sequence of
 <code>super</code> and <code>class</code> keywords.</li>
-<li>...gives you <em>lexical information</em> such as line numbers for each token. This
+<li>…gives you <em>lexical information</em> such as line numbers for each token. This
 lets you make better error messages.</li>
 </ul>
-<h3 id="lexing-with-moo">
-Lexing with Moo</h3>
-<p>The <code>@lexer</code> directive instructs Nearley to use a lexer you&apos;ve defined inside a
+<h3 id="lexing-with-moo">Lexing with Moo</h3>
+<p>The <code>@lexer</code> directive instructs Nearley to use a lexer you’ve defined inside a
 <a href="grammar#additional-js">Javascript block</a> in your grammar.</p>
 <p>nearley supports and recommends <a href="https://github.com/tjvr/moo">Moo</a>, a
 super-fast lexer. Construct a lexer using <code>moo.compile</code>.</p>
 <p>When using a lexer, there are two ways to match tokens:</p>
 <ul>
-<li>
-<p>Use <code>%token</code> to match a token with <strong>type</strong> <code>token</code>.</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">line</span> <span class="pl-k">-&gt;</span> <span class="pl-en">words</span> <span class="pl-k">%newline</span></pre></div>
+<li><p>Use <code>%token</code> to match a token with <strong>type</strong> <code>token</code>.</p>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">line</span> <span class="pl-k">-&gt;</span> <span class="pl-en">words</span> <span class="pl-k">%newline</span></pre></div></code></pre>
 </li>
-<li>
-<p>Use <code>&quot;foo&quot;</code> to match a token with <strong>text</strong> <code>foo</code>.</p>
+<li><p>Use <code>&quot;foo&quot;</code> to match a token with <strong>text</strong> <code>foo</code>.</p>
 <p>This is convenient for matching keywords:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-en">ifStatement</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;if&quot;</span> <span class="pl-en">condition</span> <span class="pl-s">&quot;then&quot;</span> <span class="pl-en">block</span></pre></div>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-en">ifStatement</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;if&quot;</span> <span class="pl-en">condition</span> <span class="pl-s">&quot;then&quot;</span> <span class="pl-en">block</span></pre></div></code></pre>
 </li>
 </ul>
 <p>Here is an example of a simple grammar:</p>
-<div class="highlight highlight-source-coffee"><pre><span class="pl-smi">@</span>{<span class="pl-k">%</span>
+<pre><code class="language-coffeescript"><div class="highlight highlight-source-coffee"><pre><span class="pl-smi">@</span>{<span class="pl-k">%</span>
 <span class="pl-k">const</span> <span class="pl-v">moo</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>moo<span class="pl-pds">&quot;</span></span>);
 
 <span class="pl-k">const</span> <span class="pl-v">lexer</span> <span class="pl-k">=</span> <span class="pl-smi">moo</span>.<span class="pl-c1">compile</span>({
@@ -331,31 +391,25 @@ super-fast lexer. Construct a lexer using <code>moo.compile</code>.</p>
 <span class="pl-en">multiplication</span> <span class="pl-k">-&gt;</span> <span class="pl-k">%</span>number <span class="pl-k">%</span>ws <span class="pl-k">%</span>times <span class="pl-k">%</span>ws <span class="pl-k">%</span><span class="pl-en">number</span> {<span class="pl-k">%</span> ([first, , , , second]) <span class="pl-k">=&gt;</span> first <span class="pl-k">*</span> second <span class="pl-k">%</span>}
 
 <span class="pl-c"><span class="pl-c">#</span> Literal strings now match tokens with that text:</span>
-<span class="pl-en">trig</span> <span class="pl-k">-&gt;</span> <span class="pl-s"><span class="pl-pds">&quot;</span>sin<span class="pl-pds">&quot;</span></span> <span class="pl-k">%</span>number</pre></div>
+<span class="pl-en">trig</span> <span class="pl-k">-&gt;</span> <span class="pl-s"><span class="pl-pds">&quot;</span>sin<span class="pl-pds">&quot;</span></span> <span class="pl-k">%</span>number</pre></div></code></pre>
 <p>Have a look at <a href="https://github.com/tjvr/moo#usage">the Moo documentation</a> to
 learn more about writing a tokenizer.</p>
 <p>You use the parser as usual: call <code>parser.feed(data)</code>, and nearley will give
 you the parsed results in return.</p>
-<h3 id="custom-lexers">
-Custom lexers</h3>
+<h3 id="custom-lexers">Custom lexers</h3>
 <p>nearley recommends using a <a href="https://github.com/tjvr/moo">moo</a>-based lexer.
 However, you can use any lexer that conforms to the following interface:</p>
 <ul>
-<li>
-<code>next()</code> returns a token object, which could have fields for line number,
+<li><code>next()</code> returns a token object, which could have fields for line number,
 etc. Importantly, a token object <em>must</em> have a <code>value</code> attribute.</li>
-<li>
-<code>save()</code> returns an info object that describes the current state of the
+<li><code>save()</code> returns an info object that describes the current state of the
 lexer. nearley places no restrictions on this object.</li>
-<li>
-<code>reset(chunk, info)</code> sets the internal buffer of the lexer to <code>chunk</code>, and
+<li><code>reset(chunk, info)</code> sets the internal buffer of the lexer to <code>chunk</code>, and
 restores its state to a state returned by <code>save()</code>.</li>
-<li>
-<code>formatError(token)</code> returns a string with an error message describing a
+<li><code>formatError(token)</code> returns a string with an error message describing a
 parse error at that token (for example, the string might contain the line and
 column where the error was found).</li>
-<li>
-<code>has(name)</code> returns true if the lexer can emit tokens with that name. This is
+<li><code>has(name)</code> returns true if the lexer can emit tokens with that name. This is
 used to resolve <code>%</code>-specifiers in compiled nearley grammars.</li>
 </ul>
 <blockquote>
@@ -363,8 +417,7 @@ used to resolve <code>%</code>-specifiers in compiled nearley grammars.</li>
 grammars (like in Python), you can still use moo. See <a href="https://gist.github.com/nathan/d8d1adea38a1ef3a6d6a06552da641aa">this
 example</a></p>
 </blockquote>
-<h3 id="custom-token-matchers">
-Custom token matchers</h3>
+<h3 id="custom-token-matchers">Custom token matchers</h3>
 <p>Aside from the lexer infrastructure, nearley provides a lightweight way to
 parse arbitrary streams.</p>
 <p>Custom matchers can be defined in two ways: <em>literal</em> tokens and <em>testable</em>
@@ -372,53 +425,58 @@ tokens. A literal token matches a JS value exactly (with <code>===</code>), whil
 testable token runs a predicate that tests whether or not the value matches.</p>
 <p>Note that in this case, you would feed a <code>Parser</code> instance an <em>array</em> of
 objects rather than a string! Here is a simple example:</p>
-<div class="highlight highlight-source-ne"><pre><span class="pl-c">@{%</span>
+<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-c">@{%</span>
 <span class="pl-k">const</span> <span class="pl-c1">tokenPrint</span> <span class="pl-k">=</span> { literal<span class="pl-k">:</span> <span class="pl-s"><span class="pl-pds">&quot;</span>print<span class="pl-pds">&quot;</span></span> };
 <span class="pl-k">const</span> <span class="pl-c1">tokenNumber</span> <span class="pl-k">=</span> { <span class="pl-en">test</span><span class="pl-k">:</span> <span class="pl-smi">x</span> <span class="pl-k">=&gt;</span> <span class="pl-c1">Number</span>.<span class="pl-en">isInteger</span>(x) };
 <span class="pl-c">%}</span>
 
 <span class="pl-en">main</span> <span class="pl-k">-&gt;</span> <span class="pl-k">%tokenPrint</span> <span class="pl-k">%tokenNumber</span> <span class="pl-s">&quot;;;&quot;</span>
 
-<span class="pl-c"># parser.feed([&quot;print&quot;, 12, &quot;;;&quot;]);</span></pre></div>
-</body></html>
-
-    <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
-    href="http://hardmath123.github.io">Hardmath123</a> (<a
-    href="http://github.com/Hardmath123">Github</a>). You're welcome to
-    leave questions, comments, advice, or ideas as Github issues. And
-    feel free to fork nearley with your own experiments!<br/>
-
-    <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
-    <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
-</div>
+<span class="pl-c"># parser.feed([&quot;print&quot;, 12, &quot;;;&quot;]);</span></pre></div></code></pre>
 
 
-<script>
-window.addEventListener("scroll", onScroll);
-window.addEventListener("resize", onScroll);
+    <div id="footer">
+      <p>nearley is MIT-licensed. It's maintained by
+        <a href="http://hardmath123.github.io">Hardmath123</a> (
+        <a href="http://github.com/Hardmath123">Github</a>). You're welcome to leave questions, comments, advice, or ideas as Github issues. And feel free to fork
+        nearley with your own experiments!
+        <br/>
 
-var timeout;
-function onScroll(e) {
-  if (timeout) clearTimeout(timeout);
-  timeout = setTimeout(scrollEnd, 50);
-}
+        <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
+          <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo" />
+        </a>
+    </div>
 
-function scrollEnd() {
-  var headings = document.querySelectorAll("h3");
-  var offset = 60;
-  for (var i = headings.length; i--; ) {
-    var h3 = headings[i];
-    if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector(".page-heading-active");
-      if (cur) cur.className = "page-heading";
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
-        "page-heading page-heading-active";
-      return;
-    }
-  }
-}
-</script>
+    <script>
+      window.addEventListener('scroll', onScroll)
+      window.addEventListener('resize', onScroll)
+      var timeout
+      function onScroll(e) {
+        if (timeout) clearTimeout(timeout)
+        timeout = setTimeout(scrollEnd, 50)
+      }
+      function scrollEnd() {
+        var headings = document.querySelectorAll('h3')
+        var offset = 60
+        for (var i = headings.length; i--;) {
+          var h3 = headings[i]
+          if (h3.offsetTop < window.scrollY + offset) {
+            var cur = document.querySelector('.page-heading-active')
+            if (cur) cur.className = 'page-heading'
+            document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
+            return
+          }
+        }
+      }
+    </script>
 
-<script>
-(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
-</script>
+    <script>
+      (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-46120535-5', 'auto');
+      ga('send', 'pageview');
+    </script>

--- a/docs/tooling.html
+++ b/docs/tooling.html
@@ -241,8 +241,6 @@ nav ul a {
     }
 }
 
-/* highlight.js */
-
 .highlight pre {
   display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
 }
@@ -403,25 +401,5 @@ function scrollEnd() {
 </script>
 
 <script>
-(function(i, s, o, g, r, a, m) {
-  i["GoogleAnalyticsObject"] = r;
-  (i[r] =
-    i[r] ||
-    function() {
-      (i[r].q = i[r].q || []).push(arguments);
-    }),
-    (i[r].l = 1 * new Date());
-  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-  a.async = 1;
-  a.src = g;
-  m.parentNode.insertBefore(a, m);
-})(
-  window,
-  document,
-  "script",
-  "https://www.google-analytics.com/analytics.js",
-  "ga"
-);
-ga("create", "UA-46120535-5", "auto");
-ga("send", "pageview");
+(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
 </script>

--- a/docs/tooling.html
+++ b/docs/tooling.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <title>Tooling - nearley.js - JS Parsing Toolkit</title>
-<meta charset="utf-8"/>
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
-@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
+  @import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -145,11 +145,23 @@ code {
 
 pre code, .highlight pre {
     border-radius: 0.5em;
-    padding: 0.5em;
+    margin: 5px;
+    padding: 10px;
     display: block;
     overflow: auto;
 }
 
+.highlight pre {
+    padding: 0;
+    margin: 0;
+    display: block;
+    overflow-x: auto;
+}
+
+pre > code > pre > code {
+    padding: 0;
+    margin: 0;
+}
 
 ol {
     counter-reset: tutorial-counter;
@@ -206,7 +218,7 @@ nav ul a {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 0.25em 0.5em; */
+    padding: 0.25em 0.5em;
 }
 .page {
     display: block;
@@ -241,94 +253,141 @@ nav ul a {
     }
 }
 
-.highlight pre {
-  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+code pre {
+    margin: 0;
 }
-
 </style>
 
-<body class="docs-page">
+<body class="docs-page" >
 
-<a href="https://github.com/kach/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-<nav id="nav">
-    <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">2.12.1</span></a></h1>
+  <a href="https://github.com/kach/nearley" class="github-corner">
+    <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg>
+  </a>
+  <style>
+    .github-corner:hover .octo-arm {
+      animation: octocat-wave 560ms ease-in-out
+    }
+
+    @keyframes octocat-wave {
+      0%,
+      100% {
+        transform: rotate(0)
+      }
+      20%,
+      60% {
+        transform: rotate(-25deg)
+      }
+      40%,
+      80% {
+        transform: rotate(10deg)
+      }
+    }
+
+    @media (max-width:500px) {
+      .github-corner:hover .octo-arm {
+        animation: none
+      }
+      .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out
+      }
+    }
+  </style>
+  <nav id="nav">
+    <h1>
+      <a href="/">nearley
+        <span style="color: #559;">.js</span>
+        <span id="version">2.12.1</span>
+      </a>
+    </h1>
     <ul>
-        <li class="page"><a href="/docs/index">Home</a>
-        <li class="page"><a href="/docs/getting-started">Getting started</a>
-        <li class="page"><a href="/docs/grammar">Writing a parser</a>
-        <li class="page"><a href="/docs/parser">Using a parser</a>
-        <li class="page"><a href="/docs/tokenizers">Tokenizers</a>
-        <li class="page">
-            <a href="#" class="page-title-active">Tooling</a>
-            <ul>
-                <li class="page-heading"><a href="#nearley-test-exploring-a-parser-interactively">
-nearley-test: Exploring a parser interactively</a></li>
-                <li class="page-heading"><a href="#nearley-unparse-the-unparser">
-nearley-unparse: The Unparser</a></li>
-                <li class="page-heading"><a href="#nearley-railroad-automagical-railroad-diagrams">
-nearley-railroad: Automagical Railroad Diagrams</a></li>
-                <li class="page-heading"><a href="#other-tools">
-Other Tools</a></li>
-            </ul>
+               <li class="page">
+          <a href="/docs/index">Home</a>
+                    <li class="page">
+          <a href="/docs/getting-started">Getting started</a>
+                    <li class="page">
+          <a href="/docs/grammar">Writing a parser</a>
+                    <li class="page">
+          <a href="/docs/parser">Using a parser</a>
+                    <li class="page">
+          <a href="/docs/tokenizers">Tokenizers</a>
+            
+      <li class="page">
+        <a href="#" class="page-title-active">Tooling</a>
+        <ul>
+          <li class="page-heading">
+            <a href="#nearley-test-exploring-a-parser-interactively">nearley-test: Exploring a parser interactively</a>
+          <li class="page-heading">
+            <a href="#nearley-unparse-the-unparser">nearley-unparse: The Unparser</a>
+          <li class="page-heading">
+            <a href="#nearley-railroad-automagical-railroad-diagrams">nearley-railroad: Automagical Railroad Diagrams</a>
+          <li class="page-heading">
+            <a href="#other-tools">Other Tools</a>
+        </ul>
         </li>
-        <li class="page"><a href="/docs/how-to-grammar-good">How to grammar good</a>
-        <li class="page"><a href="/docs/using-in-frontend">Compiling in browsers</a>
-        <li class="page"><a href="/docs/glossary">Glossary</a>
+          <li class="page">
+          <a href="/docs/how-to-grammar-good">How to grammar good</a>
+                    <li class="page">
+          <a href="/docs/using-in-frontend">Compiling in browsers</a>
+                    <li class="page">
+          <a href="/docs/glossary">Glossary</a>
+           
     </ul>
-</nav>
+  </nav>
 
-<div id="main" class="center">
+  <div id="main" class="center">
 
-<h2>Tooling</h2>
-<html><head></head><body><p>nearley ships with a host of tools to help you develop, test, and maintain your
+    <h2>Tooling</h2>
+    <p>nearley ships with a host of tools to help you develop, test, and maintain your
 grammars easily.</p>
-<h3 id="nearley-test-exploring-a-parser-interactively">
-nearley-test: Exploring a parser interactively</h3>
+<h3 id="nearley-test-exploring-a-parser-interactively">nearley-test: Exploring a parser interactively</h3>
 <p>A global install of nearley provides <code>nearley-test</code>, a simple command-line tool
 you can use to inspect what a parser is doing. You input a generated
 <code>grammar.js</code> file, and then give it some input to test the parser against.
 <code>nearley-test</code> prints out the output if successful, and optionally
 pretty-prints the internal parse table used by the algorithm. This is helpful
 to test a new parser.</p>
-<h3 id="nearley-unparse-the-unparser">
-nearley-unparse: The Unparser</h3>
+<h3 id="nearley-unparse-the-unparser">nearley-unparse: The Unparser</h3>
 <p>The Unparser takes a (compiled) parser and outputs a random string that would
 be accepted by the parser.</p>
-<div class="highlight highlight-source-shell"><pre>$ nearley-unparse -s number <span class="pl-s"><span class="pl-pds">&lt;(</span>nearleyc builtin/prims.ne<span class="pl-pds">)</span></span>
--6.22E94</pre></div>
-<p>You can use the Unparser to...</p>
+<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ nearley-unparse -s number <span class="pl-s"><span class="pl-pds">&lt;(</span>nearleyc builtin/prims.ne<span class="pl-pds">)</span></span>
+-6.22E94</pre></div></code></pre>
+<p>You can use the Unparser to…</p>
 <ul>
-<li>...test your parser specification by generating lots of random expressions
-and making sure all of them are &quot;correct&quot;.</li>
-<li>...generate random strings from a schema (for example, random email addresses
+<li>…test your parser specification by generating lots of random expressions
+and making sure all of them are “correct”.</li>
+<li>…generate random strings from a schema (for example, random email addresses
 or telephone numbers).</li>
-<li>...create fuzzers and combinatorial stress-testers.</li>
-<li>...play &quot;Mad-Libs&quot; automatically! (Practical application: automatic
+<li>…create fuzzers and combinatorial stress-testers.</li>
+<li>…play “Mad-Libs” automatically! (Practical application: automatic
 grammatically valid loremtext.)</li>
 </ul>
 <p>The Unparser outputs as a stream by continuously writing characters to its
-output pipe. So, if it &quot;goes off the deep end&quot; and generates a huge string, you
+output pipe. So, if it “goes off the deep end” and generates a huge string, you
 will still see output scrolling by in real-time.</p>
 <p>To limit the size of the output, you can specify a bound on the depth with the
 <code>-d</code> flag. This switches the Unparser to a different algorithm. A larger depth
 bound corresponds to larger generated strings.</p>
 <p>As far as I know, nearley is the only parser generator with this feature. It
-is inspired by Roly Fentanes&apos; <a href="https://fent.github.io/randexp.js/" rel="nofollow">randexp</a>,
+is inspired by Roly Fentanes’ <a href="https://fent.github.io/randexp.js/">randexp</a>,
 which does the same thing with regular expressions.</p>
 <p>Chase Meadors wrote a standalone nearley-unparse module,
 <a href="https://github.com/cemulate/nearley-generator">nearley-generator</a>.</p>
-<h3 id="nearley-railroad-automagical-railroad-diagrams">
-nearley-railroad: Automagical Railroad Diagrams</h3>
+<h3 id="nearley-railroad-automagical-railroad-diagrams">nearley-railroad: Automagical Railroad Diagrams</h3>
 <p>nearley lets you convert your grammars to pretty SVG railroad diagrams that you
 can include in webpages, documentation, and even papers.</p>
-<div class="highlight highlight-source-shell"><pre>$ nearley-railroad regex.ne -o grammar.html</pre></div>
-<p><a href="/www/railroad-demo.png" target="_blank"><img src="/www/railroad-demo.png" alt="Railroad demo" style="max-width:100%;"></a></p>
+<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ nearley-railroad regex.ne -o grammar.html</pre></div></code></pre>
+<p><img src="/www/railroad-demo.png" alt="Railroad demo"></p>
 <p>See a bigger example <a href="/www/railroad-demo">here</a>.</p>
 <p>(This feature is powered by
 <a href="https://github.com/tabatkins/railroad-diagrams"><code>railroad-diagrams</code></a> by
 tabatkins.)</p>
-<h3 id="other-tools">
-Other Tools</h3>
+<h3 id="other-tools">Other Tools</h3>
 <p><em>This section lists nearley tooling created by other developers. These tools
 are not distributed with nearley, so if you have problems, please contact the
 respective author for support instead of opening an issue with nearley.</em></p>
@@ -340,7 +399,7 @@ language</a> by yours truly.</p>
 syntax</a> by liam4.</p>
 <p><strong>Vim</strong> users can use <a href="https://github.com/tjvr/vim-nearley">this plugin</a> by Tim
 (based on <a href="https://github.com/andres-arana/vim-nearley">this older plugin</a> by
-Andr&#xE9;s Arana).</p>
+Andrés Arana).</p>
 <p><strong>Visual Studio Code</strong> users can use <a href="https://github.com/karyfoundation/nearley-vscode">this
 extension</a> by Pouya Kary.</p>
 <p><strong>Python</strong> users can convert nearley grammars to Python using
@@ -350,56 +409,61 @@ Erez.</p>
 <a href="https://github.com/stolksdorf/nearley-there">nearley-there</a> by Scott
 Tolksdorf.</p>
 <p><strong>Browser</strong> users can use
-<a href="https://omrelli.ug/nearley-playground/" rel="nofollow">nearley-playground</a> by Guillermo
+<a href="https://omrelli.ug/nearley-playground/">nearley-playground</a> by Guillermo
 Webster to explore nearley interactively in the browser. There is also a <a href="https://github.com/pmkary/nearley-playground-mac">Mac
 app</a> by Pouya Kary.</p>
 <p><strong>Webpack</strong> users can use
-<a href="https://github.com/kozily/nearley-loader">nearley-loader</a> by Andr&#xE9;s Arana to
+<a href="https://github.com/kozily/nearley-loader">nearley-loader</a> by Andrés Arana to
 load grammars directly.</p>
 <p><strong>Gulp</strong> users can use
 <a href="https://github.com/JosephJNK/gulp-nearley">gulp-nearley</a> by Joseph Junker to
 compile grammars with a gulpfile.</p>
 <p><strong>Node</strong> users can quickly create the framework for a large nearley-based
 project using <a href="https://github.com/appology/nearley-template">nearley-template</a>.</p>
-</body></html>
-
-    <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
-    href="http://hardmath123.github.io">Hardmath123</a> (<a
-    href="http://github.com/Hardmath123">Github</a>). You're welcome to
-    leave questions, comments, advice, or ideas as Github issues. And
-    feel free to fork nearley with your own experiments!<br/>
-
-    <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
-    <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
-</div>
 
 
-<script>
-window.addEventListener("scroll", onScroll);
-window.addEventListener("resize", onScroll);
+    <div id="footer">
+      <p>nearley is MIT-licensed. It's maintained by
+        <a href="http://hardmath123.github.io">Hardmath123</a> (
+        <a href="http://github.com/Hardmath123">Github</a>). You're welcome to leave questions, comments, advice, or ideas as Github issues. And feel free to fork
+        nearley with your own experiments!
+        <br/>
 
-var timeout;
-function onScroll(e) {
-  if (timeout) clearTimeout(timeout);
-  timeout = setTimeout(scrollEnd, 50);
-}
+        <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
+          <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo" />
+        </a>
+    </div>
 
-function scrollEnd() {
-  var headings = document.querySelectorAll("h3");
-  var offset = 60;
-  for (var i = headings.length; i--; ) {
-    var h3 = headings[i];
-    if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector(".page-heading-active");
-      if (cur) cur.className = "page-heading";
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
-        "page-heading page-heading-active";
-      return;
-    }
-  }
-}
-</script>
+    <script>
+      window.addEventListener('scroll', onScroll)
+      window.addEventListener('resize', onScroll)
+      var timeout
+      function onScroll(e) {
+        if (timeout) clearTimeout(timeout)
+        timeout = setTimeout(scrollEnd, 50)
+      }
+      function scrollEnd() {
+        var headings = document.querySelectorAll('h3')
+        var offset = 60
+        for (var i = headings.length; i--;) {
+          var h3 = headings[i]
+          if (h3.offsetTop < window.scrollY + offset) {
+            var cur = document.querySelector('.page-heading-active')
+            if (cur) cur.className = 'page-heading'
+            document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
+            return
+          }
+        }
+      }
+    </script>
 
-<script>
-(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
-</script>
+    <script>
+      (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-46120535-5', 'auto');
+      ga('send', 'pageview');
+    </script>

--- a/docs/tooling.html
+++ b/docs/tooling.html
@@ -4,6 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
+@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -142,7 +143,7 @@ code {
     background-color: #eee;
 }
 
-pre code {
+pre code, .highlight pre {
     border-radius: 0.5em;
     padding: 0.5em;
     display: block;
@@ -242,8 +243,9 @@ nav ul a {
 
 /* highlight.js */
 
-.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
-
+.highlight pre {
+  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+}
 
 </style>
 
@@ -261,10 +263,14 @@ nav ul a {
         <li class="page">
             <a href="#" class="page-title-active">Tooling</a>
             <ul>
-                <li class="page-heading"><a href="#nearley-test-exploring-a-parser-interactively">nearley-test: Exploring a parser interactively</a>
-                <li class="page-heading"><a href="#nearley-unparse-the-unparser">nearley-unparse: The Unparser</a>
-                <li class="page-heading"><a href="#nearley-railroad-automagical-railroad-diagrams">nearley-railroad: Automagical Railroad Diagrams</a>
-                <li class="page-heading"><a href="#other-tools">Other Tools</a>
+                <li class="page-heading"><a href="#nearley-test-exploring-a-parser-interactively">
+nearley-test: Exploring a parser interactively</a></li>
+                <li class="page-heading"><a href="#nearley-unparse-the-unparser">
+nearley-unparse: The Unparser</a></li>
+                <li class="page-heading"><a href="#nearley-railroad-automagical-railroad-diagrams">
+nearley-railroad: Automagical Railroad Diagrams</a></li>
+                <li class="page-heading"><a href="#other-tools">
+Other Tools</a></li>
             </ul>
         </li>
         <li class="page"><a href="/docs/how-to-grammar-good">How to grammar good</a>
@@ -276,53 +282,55 @@ nav ul a {
 <div id="main" class="center">
 
 <h2>Tooling</h2>
-<p>nearley ships with a host of tools to help you develop, test, and maintain your
+<html><head></head><body><p>nearley ships with a host of tools to help you develop, test, and maintain your
 grammars easily.</p>
-<h3 id="nearley-test-exploring-a-parser-interactively">nearley-test: Exploring a parser interactively</h3>
+<h3 id="nearley-test-exploring-a-parser-interactively">
+nearley-test: Exploring a parser interactively</h3>
 <p>A global install of nearley provides <code>nearley-test</code>, a simple command-line tool
 you can use to inspect what a parser is doing. You input a generated
 <code>grammar.js</code> file, and then give it some input to test the parser against.
 <code>nearley-test</code> prints out the output if successful, and optionally
 pretty-prints the internal parse table used by the algorithm. This is helpful
 to test a new parser.</p>
-<h3 id="nearley-unparse-the-unparser">nearley-unparse: The Unparser</h3>
+<h3 id="nearley-unparse-the-unparser">
+nearley-unparse: The Unparser</h3>
 <p>The Unparser takes a (compiled) parser and outputs a random string that would
 be accepted by the parser.</p>
-<pre><code class="lang-bash">$ nearley-unparse -s number &lt;(nearleyc builtin/prims.ne)
--6.22E94
-</code></pre>
-<p>You can use the Unparser to…</p>
+<div class="highlight highlight-source-shell"><pre>$ nearley-unparse -s number <span class="pl-s"><span class="pl-pds">&lt;(</span>nearleyc builtin/prims.ne<span class="pl-pds">)</span></span>
+-6.22E94</pre></div>
+<p>You can use the Unparser to...</p>
 <ul>
-<li>…test your parser specification by generating lots of random expressions
-and making sure all of them are “correct”.</li>
-<li>…generate random strings from a schema (for example, random email addresses
+<li>...test your parser specification by generating lots of random expressions
+and making sure all of them are &quot;correct&quot;.</li>
+<li>...generate random strings from a schema (for example, random email addresses
 or telephone numbers).</li>
-<li>…create fuzzers and combinatorial stress-testers.</li>
-<li>…play “Mad-Libs” automatically! (Practical application: automatic
+<li>...create fuzzers and combinatorial stress-testers.</li>
+<li>...play &quot;Mad-Libs&quot; automatically! (Practical application: automatic
 grammatically valid loremtext.)</li>
 </ul>
 <p>The Unparser outputs as a stream by continuously writing characters to its
-output pipe. So, if it “goes off the deep end” and generates a huge string, you
+output pipe. So, if it &quot;goes off the deep end&quot; and generates a huge string, you
 will still see output scrolling by in real-time.</p>
 <p>To limit the size of the output, you can specify a bound on the depth with the
 <code>-d</code> flag. This switches the Unparser to a different algorithm. A larger depth
 bound corresponds to larger generated strings.</p>
 <p>As far as I know, nearley is the only parser generator with this feature. It
-is inspired by Roly Fentanes’ <a href="https://fent.github.io/randexp.js/">randexp</a>,
+is inspired by Roly Fentanes&apos; <a href="https://fent.github.io/randexp.js/" rel="nofollow">randexp</a>,
 which does the same thing with regular expressions.</p>
 <p>Chase Meadors wrote a standalone nearley-unparse module,
 <a href="https://github.com/cemulate/nearley-generator">nearley-generator</a>.</p>
-<h3 id="nearley-railroad-automagical-railroad-diagrams">nearley-railroad: Automagical Railroad Diagrams</h3>
+<h3 id="nearley-railroad-automagical-railroad-diagrams">
+nearley-railroad: Automagical Railroad Diagrams</h3>
 <p>nearley lets you convert your grammars to pretty SVG railroad diagrams that you
 can include in webpages, documentation, and even papers.</p>
-<pre><code class="lang-bash">$ nearley-railroad regex.ne -o grammar.html
-</code></pre>
-<p><img src="/www/railroad-demo.png" alt="Railroad demo"></p>
+<div class="highlight highlight-source-shell"><pre>$ nearley-railroad regex.ne -o grammar.html</pre></div>
+<p><a href="/www/railroad-demo.png" target="_blank"><img src="/www/railroad-demo.png" alt="Railroad demo" style="max-width:100%;"></a></p>
 <p>See a bigger example <a href="/www/railroad-demo">here</a>.</p>
 <p>(This feature is powered by
 <a href="https://github.com/tabatkins/railroad-diagrams"><code>railroad-diagrams</code></a> by
 tabatkins.)</p>
-<h3 id="other-tools">Other Tools</h3>
+<h3 id="other-tools">
+Other Tools</h3>
 <p><em>This section lists nearley tooling created by other developers. These tools
 are not distributed with nearley, so if you have problems, please contact the
 respective author for support instead of opening an issue with nearley.</em></p>
@@ -334,7 +342,7 @@ language</a> by yours truly.</p>
 syntax</a> by liam4.</p>
 <p><strong>Vim</strong> users can use <a href="https://github.com/tjvr/vim-nearley">this plugin</a> by Tim
 (based on <a href="https://github.com/andres-arana/vim-nearley">this older plugin</a> by
-Andrés Arana).</p>
+Andr&#xE9;s Arana).</p>
 <p><strong>Visual Studio Code</strong> users can use <a href="https://github.com/karyfoundation/nearley-vscode">this
 extension</a> by Pouya Kary.</p>
 <p><strong>Python</strong> users can convert nearley grammars to Python using
@@ -344,70 +352,76 @@ Erez.</p>
 <a href="https://github.com/stolksdorf/nearley-there">nearley-there</a> by Scott
 Tolksdorf.</p>
 <p><strong>Browser</strong> users can use
-<a href="https://omrelli.ug/nearley-playground/">nearley-playground</a> by Guillermo
+<a href="https://omrelli.ug/nearley-playground/" rel="nofollow">nearley-playground</a> by Guillermo
 Webster to explore nearley interactively in the browser. There is also a <a href="https://github.com/pmkary/nearley-playground-mac">Mac
 app</a> by Pouya Kary.</p>
 <p><strong>Webpack</strong> users can use
-<a href="https://github.com/kozily/nearley-loader">nearley-loader</a> by Andrés Arana to
+<a href="https://github.com/kozily/nearley-loader">nearley-loader</a> by Andr&#xE9;s Arana to
 load grammars directly.</p>
 <p><strong>Gulp</strong> users can use
 <a href="https://github.com/JosephJNK/gulp-nearley">gulp-nearley</a> by Joseph Junker to
 compile grammars with a gulpfile.</p>
 <p><strong>Node</strong> users can quickly create the framework for a large nearley-based
 project using <a href="https://github.com/appology/nearley-template">nearley-template</a>.</p>
-
+</body></html>
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
     href="http://hardmath123.github.io">Hardmath123</a> (<a
     href="http://github.com/Hardmath123">Github</a>). You're welcome to
     leave questions, comments, advice, or ideas as Github issues. And
     feel free to fork nearley with your own experiments!<br/>
-    
+
     <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
     <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
 </div>
 
-<script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>
-document.querySelector('#highlight-js').addEventListener('load', function() {
-    [].slice.apply(document.querySelectorAll('pre code')).forEach(function(b) {
-        hljs.highlightBlock(b)
-    })
-})
-</script>
-
 
 <script>
-window.addEventListener('scroll', onScroll)
-window.addEventListener('resize', onScroll)
+window.addEventListener("scroll", onScroll);
+window.addEventListener("resize", onScroll);
 
-var timeout
+var timeout;
 function onScroll(e) {
-    if (timeout) clearTimeout(timeout)
-    timeout = setTimeout(scrollEnd, 50)
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(scrollEnd, 50);
 }
 
 function scrollEnd() {
-  var headings = document.querySelectorAll('h3')
-  var offset = 60
-  for (var i=headings.length; i--; ) {
-    var h3 = headings[i]
+  var headings = document.querySelectorAll("h3");
+  var offset = 60;
+  for (var i = headings.length; i--; ) {
+    var h3 = headings[i];
     if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector('.page-heading-active')
-      if (cur) cur.className = 'page-heading'
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
-      return
+      var cur = document.querySelector(".page-heading-active");
+      if (cur) cur.className = "page-heading";
+      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
+        "page-heading page-heading-active";
+      return;
     }
   }
 }
 </script>
 
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-46120535-5', 'auto');
-ga('send', 'pageview');
+(function(i, s, o, g, r, a, m) {
+  i["GoogleAnalyticsObject"] = r;
+  (i[r] =
+    i[r] ||
+    function() {
+      (i[r].q = i[r].q || []).push(arguments);
+    }),
+    (i[r].l = 1 * new Date());
+  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+  a.async = 1;
+  a.src = g;
+  m.parentNode.insertBefore(a, m);
+})(
+  window,
+  document,
+  "script",
+  "https://www.google-analytics.com/analytics.js",
+  "ga"
+);
+ga("create", "UA-46120535-5", "auto");
+ga("send", "pageview");
 </script>
-

--- a/docs/tooling.html
+++ b/docs/tooling.html
@@ -458,12 +458,12 @@ project using <a href="https://github.com/appology/nearley-template">nearley-tem
     </script>
 
     <script>
-      (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-      ga('create', 'UA-46120535-5', 'auto');
-      ga('send', 'pageview');
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-46120535-5', 'auto');
+ga('send', 'pageview');
     </script>
+  </div>
+</body>

--- a/docs/using-in-frontend.html
+++ b/docs/using-in-frontend.html
@@ -407,12 +407,12 @@ the <code>nearleyc</code> internals to compile grammars dynamically.</p>
     </script>
 
     <script>
-      (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-      ga('create', 'UA-46120535-5', 'auto');
-      ga('send', 'pageview');
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-46120535-5', 'auto');
+ga('send', 'pageview');
     </script>
+  </div>
+</body>

--- a/docs/using-in-frontend.html
+++ b/docs/using-in-frontend.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <title>Compiling in browsers - nearley.js - JS Parsing Toolkit</title>
-<meta charset="utf-8"/>
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
-@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
+  @import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -145,11 +145,23 @@ code {
 
 pre code, .highlight pre {
     border-radius: 0.5em;
-    padding: 0.5em;
+    margin: 5px;
+    padding: 10px;
     display: block;
     overflow: auto;
 }
 
+.highlight pre {
+    padding: 0;
+    margin: 0;
+    display: block;
+    overflow-x: auto;
+}
+
+pre > code > pre > code {
+    padding: 0;
+    margin: 0;
+}
 
 ol {
     counter-reset: tutorial-counter;
@@ -206,7 +218,7 @@ nav ul a {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 0.25em 0.5em; */
+    padding: 0.25em 0.5em;
 }
 .page {
     display: block;
@@ -241,46 +253,97 @@ nav ul a {
     }
 }
 
-.highlight pre {
-  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+code pre {
+    margin: 0;
 }
-
 </style>
 
-<body class="docs-page">
+<body class="docs-page" >
 
-<a href="https://github.com/kach/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-<nav id="nav">
-    <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">2.12.1</span></a></h1>
+  <a href="https://github.com/kach/nearley" class="github-corner">
+    <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg>
+  </a>
+  <style>
+    .github-corner:hover .octo-arm {
+      animation: octocat-wave 560ms ease-in-out
+    }
+
+    @keyframes octocat-wave {
+      0%,
+      100% {
+        transform: rotate(0)
+      }
+      20%,
+      60% {
+        transform: rotate(-25deg)
+      }
+      40%,
+      80% {
+        transform: rotate(10deg)
+      }
+    }
+
+    @media (max-width:500px) {
+      .github-corner:hover .octo-arm {
+        animation: none
+      }
+      .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out
+      }
+    }
+  </style>
+  <nav id="nav">
+    <h1>
+      <a href="/">nearley
+        <span style="color: #559;">.js</span>
+        <span id="version">2.12.1</span>
+      </a>
+    </h1>
     <ul>
-        <li class="page"><a href="/docs/index">Home</a>
-        <li class="page"><a href="/docs/getting-started">Getting started</a>
-        <li class="page"><a href="/docs/grammar">Writing a parser</a>
-        <li class="page"><a href="/docs/parser">Using a parser</a>
-        <li class="page"><a href="/docs/tokenizers">Tokenizers</a>
-        <li class="page"><a href="/docs/tooling">Tooling</a>
-        <li class="page"><a href="/docs/how-to-grammar-good">How to grammar good</a>
-        <li class="page">
-            <a href="#" class="page-title-active">Compiling in browsers</a>
+               <li class="page">
+          <a href="/docs/index">Home</a>
+                    <li class="page">
+          <a href="/docs/getting-started">Getting started</a>
+                    <li class="page">
+          <a href="/docs/grammar">Writing a parser</a>
+                    <li class="page">
+          <a href="/docs/parser">Using a parser</a>
+                    <li class="page">
+          <a href="/docs/tokenizers">Tokenizers</a>
+                    <li class="page">
+          <a href="/docs/tooling">Tooling</a>
+                    <li class="page">
+          <a href="/docs/how-to-grammar-good">How to grammar good</a>
+            
+      <li class="page">
+        <a href="#" class="page-title-active">Compiling in browsers</a>
         </li>
-        <li class="page"><a href="/docs/glossary">Glossary</a>
+          <li class="page">
+          <a href="/docs/glossary">Glossary</a>
+           
     </ul>
-</nav>
+  </nav>
 
-<div id="main" class="center">
+  <div id="main" class="center">
 
-<h2>Compiling in browsers</h2>
-<html><head></head><body><p>Both the nearley parser and compiled grammars work in browsers; simply include
+    <h2>Compiling in browsers</h2>
+    <p>Both the nearley parser and compiled grammars work in browsers; simply include
 <code>nearley.js</code> and your compiled <code>grammar.js</code> file in <code>&lt;script&gt;</code> tags and use
 nearley as usual. However, the nearley <em>compiler</em> is not designed for the
-browser -- you should precompile your grammars and only serve the generated JS
+browser – you should precompile your grammars and only serve the generated JS
 files to browsers.</p>
 <p>If you absolutely have to compile a grammar in a browser (for example, to
 implement a nearley IDE) then you can use a tool like
-<a href="https://webpack.js.org/" rel="nofollow">Webpack</a> or <a href="https://rollupjs.org/" rel="nofollow">Rollup</a> to
+<a href="https://webpack.js.org/">Webpack</a> or <a href="https://rollupjs.org/">Rollup</a> to
 include the <code>nearley</code> NPM package in your browser code. Then, you can utilize
 the <code>nearleyc</code> internals to compile grammars dynamically.</p>
-<div class="highlight highlight-source-js"><pre><span class="pl-k">const</span> <span class="pl-c1">nearley</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley<span class="pl-pds">&quot;</span></span>);
+<pre><code class="language-js"><div class="highlight highlight-source-js"><pre><span class="pl-k">const</span> <span class="pl-c1">nearley</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley<span class="pl-pds">&quot;</span></span>);
 <span class="pl-k">const</span> <span class="pl-c1">compile</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley/lib/compile<span class="pl-pds">&quot;</span></span>);
 <span class="pl-k">const</span> <span class="pl-c1">generate</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley/lib/generate<span class="pl-pds">&quot;</span></span>);
 <span class="pl-k">const</span> <span class="pl-c1">nearleyGrammar</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley/lib/nearley-language-bootstrapped<span class="pl-pds">&quot;</span></span>);
@@ -305,46 +368,51 @@ the <code>nearleyc</code> internals to compile grammars dynamically.</p>
 
 <span class="pl-k">const</span> <span class="pl-c1">grammar</span> <span class="pl-k">=</span> <span class="pl-en">compileGrammar</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>main -&gt; foo | bar<span class="pl-pds">&quot;</span></span>);
 
-<span class="pl-k">const</span> <span class="pl-c1">parser</span> <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">nearley.Parser</span>(<span class="pl-smi">nearley</span>.<span class="pl-smi">Grammar</span>.<span class="pl-en">fromCompiled</span>(grammar));</pre></div>
-</body></html>
-
-    <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
-    href="http://hardmath123.github.io">Hardmath123</a> (<a
-    href="http://github.com/Hardmath123">Github</a>). You're welcome to
-    leave questions, comments, advice, or ideas as Github issues. And
-    feel free to fork nearley with your own experiments!<br/>
-
-    <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
-    <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
-</div>
+<span class="pl-k">const</span> <span class="pl-c1">parser</span> <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">nearley.Parser</span>(<span class="pl-smi">nearley</span>.<span class="pl-smi">Grammar</span>.<span class="pl-en">fromCompiled</span>(grammar));</pre></div></code></pre>
 
 
-<script>
-window.addEventListener("scroll", onScroll);
-window.addEventListener("resize", onScroll);
+    <div id="footer">
+      <p>nearley is MIT-licensed. It's maintained by
+        <a href="http://hardmath123.github.io">Hardmath123</a> (
+        <a href="http://github.com/Hardmath123">Github</a>). You're welcome to leave questions, comments, advice, or ideas as Github issues. And feel free to fork
+        nearley with your own experiments!
+        <br/>
 
-var timeout;
-function onScroll(e) {
-  if (timeout) clearTimeout(timeout);
-  timeout = setTimeout(scrollEnd, 50);
-}
+        <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
+          <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo" />
+        </a>
+    </div>
 
-function scrollEnd() {
-  var headings = document.querySelectorAll("h3");
-  var offset = 60;
-  for (var i = headings.length; i--; ) {
-    var h3 = headings[i];
-    if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector(".page-heading-active");
-      if (cur) cur.className = "page-heading";
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
-        "page-heading page-heading-active";
-      return;
-    }
-  }
-}
-</script>
+    <script>
+      window.addEventListener('scroll', onScroll)
+      window.addEventListener('resize', onScroll)
+      var timeout
+      function onScroll(e) {
+        if (timeout) clearTimeout(timeout)
+        timeout = setTimeout(scrollEnd, 50)
+      }
+      function scrollEnd() {
+        var headings = document.querySelectorAll('h3')
+        var offset = 60
+        for (var i = headings.length; i--;) {
+          var h3 = headings[i]
+          if (h3.offsetTop < window.scrollY + offset) {
+            var cur = document.querySelector('.page-heading-active')
+            if (cur) cur.className = 'page-heading'
+            document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
+            return
+          }
+        }
+      }
+    </script>
 
-<script>
-(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
-</script>
+    <script>
+      (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-46120535-5', 'auto');
+      ga('send', 'pageview');
+    </script>

--- a/docs/using-in-frontend.html
+++ b/docs/using-in-frontend.html
@@ -4,6 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
+@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -142,7 +143,7 @@ code {
     background-color: #eee;
 }
 
-pre code {
+pre code, .highlight pre {
     border-radius: 0.5em;
     padding: 0.5em;
     display: block;
@@ -242,8 +243,9 @@ nav ul a {
 
 /* highlight.js */
 
-.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
-
+.highlight pre {
+  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+}
 
 </style>
 
@@ -270,96 +272,101 @@ nav ul a {
 <div id="main" class="center">
 
 <h2>Compiling in browsers</h2>
-<p>Both the nearley parser and compiled grammars work in browsers; simply include
+<html><head></head><body><p>Both the nearley parser and compiled grammars work in browsers; simply include
 <code>nearley.js</code> and your compiled <code>grammar.js</code> file in <code>&lt;script&gt;</code> tags and use
 nearley as usual. However, the nearley <em>compiler</em> is not designed for the
-browser – you should precompile your grammars and only serve the generated JS
+browser -- you should precompile your grammars and only serve the generated JS
 files to browsers.</p>
 <p>If you absolutely have to compile a grammar in a browser (for example, to
 implement a nearley IDE) then you can use a tool like
-<a href="https://webpack.js.org/">Webpack</a> or <a href="https://rollupjs.org/">Rollup</a> to
+<a href="https://webpack.js.org/" rel="nofollow">Webpack</a> or <a href="https://rollupjs.org/" rel="nofollow">Rollup</a> to
 include the <code>nearley</code> NPM package in your browser code. Then, you can utilize
 the <code>nearleyc</code> internals to compile grammars dynamically.</p>
-<pre><code class="lang-js">const nearley = require(&quot;nearley&quot;);
-const compile = require(&quot;nearley/lib/compile&quot;);
-const generate = require(&quot;nearley/lib/generate&quot;);
-const nearleyGrammar = require(&quot;nearley/lib/nearley-language-bootstrapped&quot;);
+<div class="highlight highlight-source-js"><pre><span class="pl-k">const</span> <span class="pl-c1">nearley</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley<span class="pl-pds">&quot;</span></span>);
+<span class="pl-k">const</span> <span class="pl-c1">compile</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley/lib/compile<span class="pl-pds">&quot;</span></span>);
+<span class="pl-k">const</span> <span class="pl-c1">generate</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley/lib/generate<span class="pl-pds">&quot;</span></span>);
+<span class="pl-k">const</span> <span class="pl-c1">nearleyGrammar</span> <span class="pl-k">=</span> <span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>nearley/lib/nearley-language-bootstrapped<span class="pl-pds">&quot;</span></span>);
 
-function compileGrammar(sourceCode) {
-    // Parse the grammar source into an AST
-    const grammarParser = new nearley.Parser(nearleyGrammar);
-    grammarParser.feed(sourceCode);
-    const grammarAst = grammarParser.results[0]; // TODO check for errors
+<span class="pl-k">function</span> <span class="pl-en">compileGrammar</span>(<span class="pl-smi">sourceCode</span>) {
+    <span class="pl-c"><span class="pl-c">//</span> Parse the grammar source into an AST</span>
+    <span class="pl-k">const</span> <span class="pl-c1">grammarParser</span> <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">nearley.Parser</span>(nearleyGrammar);
+    <span class="pl-smi">grammarParser</span>.<span class="pl-en">feed</span>(sourceCode);
+    <span class="pl-k">const</span> <span class="pl-c1">grammarAst</span> <span class="pl-k">=</span> <span class="pl-smi">grammarParser</span>.<span class="pl-smi">results</span>[<span class="pl-c1">0</span>]; <span class="pl-c"><span class="pl-c">//</span> TODO check for errors</span>
 
-    // Compile the AST into a set of rules
-    const grammarInfoObject = compile(grammarAst, {});
-    // Generate JavaScript code from the rules
-    const grammarJs = generate(grammarInfoObject, &quot;grammar&quot;);
+    <span class="pl-c"><span class="pl-c">//</span> Compile the AST into a set of rules</span>
+    <span class="pl-k">const</span> <span class="pl-c1">grammarInfoObject</span> <span class="pl-k">=</span> <span class="pl-en">compile</span>(grammarAst, {});
+    <span class="pl-c"><span class="pl-c">//</span> Generate JavaScript code from the rules</span>
+    <span class="pl-k">const</span> <span class="pl-c1">grammarJs</span> <span class="pl-k">=</span> <span class="pl-en">generate</span>(grammarInfoObject, <span class="pl-s"><span class="pl-pds">&quot;</span>grammar<span class="pl-pds">&quot;</span></span>);
 
-    // Pretend this is a CommonJS environment to catch exports from the grammar.
-    const module = { exports: {} };
-    eval(grammarJs);
+    <span class="pl-c"><span class="pl-c">//</span> Pretend this is a CommonJS environment to catch exports from the grammar.</span>
+    <span class="pl-k">const</span> <span class="pl-c1">module</span> <span class="pl-k">=</span> { exports<span class="pl-k">:</span> {} };
+    <span class="pl-c1">eval</span>(grammarJs);
 
-    return module.exports;
+    <span class="pl-k">return</span> <span class="pl-c1">module</span>.<span class="pl-smi">exports</span>;
 }
 
-const grammar = compileGrammar(&quot;main -&gt; foo | bar&quot;);
+<span class="pl-k">const</span> <span class="pl-c1">grammar</span> <span class="pl-k">=</span> <span class="pl-en">compileGrammar</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>main -&gt; foo | bar<span class="pl-pds">&quot;</span></span>);
 
-const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
-</code></pre>
-
+<span class="pl-k">const</span> <span class="pl-c1">parser</span> <span class="pl-k">=</span> <span class="pl-k">new</span> <span class="pl-en">nearley.Parser</span>(<span class="pl-smi">nearley</span>.<span class="pl-smi">Grammar</span>.<span class="pl-en">fromCompiled</span>(grammar));</pre></div>
+</body></html>
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
     href="http://hardmath123.github.io">Hardmath123</a> (<a
     href="http://github.com/Hardmath123">Github</a>). You're welcome to
     leave questions, comments, advice, or ideas as Github issues. And
     feel free to fork nearley with your own experiments!<br/>
-    
+
     <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
     <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
 </div>
 
-<script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>
-document.querySelector('#highlight-js').addEventListener('load', function() {
-    [].slice.apply(document.querySelectorAll('pre code')).forEach(function(b) {
-        hljs.highlightBlock(b)
-    })
-})
-</script>
-
 
 <script>
-window.addEventListener('scroll', onScroll)
-window.addEventListener('resize', onScroll)
+window.addEventListener("scroll", onScroll);
+window.addEventListener("resize", onScroll);
 
-var timeout
+var timeout;
 function onScroll(e) {
-    if (timeout) clearTimeout(timeout)
-    timeout = setTimeout(scrollEnd, 50)
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(scrollEnd, 50);
 }
 
 function scrollEnd() {
-  var headings = document.querySelectorAll('h3')
-  var offset = 60
-  for (var i=headings.length; i--; ) {
-    var h3 = headings[i]
+  var headings = document.querySelectorAll("h3");
+  var offset = 60;
+  for (var i = headings.length; i--; ) {
+    var h3 = headings[i];
     if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector('.page-heading-active')
-      if (cur) cur.className = 'page-heading'
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
-      return
+      var cur = document.querySelector(".page-heading-active");
+      if (cur) cur.className = "page-heading";
+      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
+        "page-heading page-heading-active";
+      return;
     }
   }
 }
 </script>
 
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-46120535-5', 'auto');
-ga('send', 'pageview');
+(function(i, s, o, g, r, a, m) {
+  i["GoogleAnalyticsObject"] = r;
+  (i[r] =
+    i[r] ||
+    function() {
+      (i[r].q = i[r].q || []).push(arguments);
+    }),
+    (i[r].l = 1 * new Date());
+  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+  a.async = 1;
+  a.src = g;
+  m.parentNode.insertBefore(a, m);
+})(
+  window,
+  document,
+  "script",
+  "https://www.google-analytics.com/analytics.js",
+  "ga"
+);
+ga("create", "UA-46120535-5", "auto");
+ga("send", "pageview");
 </script>
-

--- a/docs/using-in-frontend.html
+++ b/docs/using-in-frontend.html
@@ -241,8 +241,6 @@ nav ul a {
     }
 }
 
-/* highlight.js */
-
 .highlight pre {
   display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
 }
@@ -348,25 +346,5 @@ function scrollEnd() {
 </script>
 
 <script>
-(function(i, s, o, g, r, a, m) {
-  i["GoogleAnalyticsObject"] = r;
-  (i[r] =
-    i[r] ||
-    function() {
-      (i[r].q = i[r].q || []).push(arguments);
-    }),
-    (i[r].l = 1 * new Date());
-  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-  a.async = 1;
-  a.src = g;
-  m.parentNode.insertBefore(a, m);
-})(
-  window,
-  document,
-  "script",
-  "https://www.google-analytics.com/analytics.js",
-  "ga"
-);
-ga("create", "UA-46120535-5", "auto");
-ga("send", "pageview");
+(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
 </script>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
+@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -142,7 +143,7 @@ code {
     background-color: #eee;
 }
 
-pre code {
+pre code, .highlight pre {
     border-radius: 0.5em;
     padding: 0.5em;
     display: block;
@@ -242,8 +243,9 @@ nav ul a {
 
 /* highlight.js */
 
-.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
-
+.highlight pre {
+  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+}
 
 </style>
 
@@ -256,10 +258,14 @@ nav ul a {
         <li class="page">
             <a href="#" class="page-title-active">Home</a>
             <ul>
-                <li class="page-heading"><a href="#nearley-101">nearley 101</a>
-                <li class="page-heading"><a href="#features">Features</a>
-                <li class="page-heading"><a href="#projects-using-nearley">Projects using nearley</a>
-                <li class="page-heading"><a href="#give-to-nearley">Give to nearley</a>
+                <li class="page-heading"><a href="#nearley-101">
+nearley 101</a></li>
+                <li class="page-heading"><a href="#features">
+Features</a></li>
+                <li class="page-heading"><a href="#projects-using-nearley">
+Projects using nearley</a></li>
+                <li class="page-heading"><a href="#give-to-nearley">
+Give to nearley</a></li>
             </ul>
         </li>
         <li class="page"><a href="/docs/getting-started">Getting started</a>
@@ -276,57 +282,61 @@ nav ul a {
 <div id="main" class="center">
 
 <h2>Home</h2>
-<p><strong>Parsers</strong> turn strings of characters into meaningful data structures (like a
+<html><head></head><body><p><strong>Parsers</strong> turn strings of characters into meaningful data structures (like a
 JSON object!). <strong>nearley</strong> is a <strong>fast</strong>, <strong>feature-rich</strong>, and <strong>modern</strong>
 parser toolkit for JavaScript. nearley is an <a href="https://github.com/npm/npm-collection-staff-picks">npm Staff
 Pick</a>.</p>
-<h3 id="nearley-101">nearley 101</h3>
+<h3 id="nearley-101">
+nearley 101</h3>
 <ol>
 <li>Install: <code>$ npm install -g nearley</code> (or try nearley live in your browser
-<a href="https://omrelli.ug/nearley-playground/">here</a>!)</li>
-<li>Write your grammar:<pre><code class="lang-ne"># Match a CSS color
-# http://www.w3.org/TR/css3-color/#colorunits
-@builtin &quot;whitespace.ne&quot; # `_` means arbitrary amount of whitespace
-@builtin &quot;number.ne&quot;     # `int`, `decimal`, and `percentage` number primitives
-csscolor -&gt; &quot;#&quot; hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit
-          | &quot;#&quot; hexdigit hexdigit hexdigit
-          | &quot;rgb&quot;  _ &quot;(&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;)&quot;
-          | &quot;hsl&quot;  _ &quot;(&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;)&quot;
-          | &quot;rgba&quot; _ &quot;(&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;,&quot; _ decimal _ &quot;)&quot;
-          | &quot;hsla&quot; _ &quot;(&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;,&quot; _ colnum _ &quot;,&quot; _ decimal _ &quot;)&quot;
-hexdigit -&gt; [a-fA-F0-9]
-colnum   -&gt; int | percentage
-</code></pre>
+<a href="https://omrelli.ug/nearley-playground/" rel="nofollow">here</a>!)</li>
+<li>Write your grammar:
+<div class="highlight highlight-source-ne"><pre><span class="pl-c"># Match a CSS color</span>
+<span class="pl-c"># http://www.w3.org/TR/css3-color/#colorunits</span>
+<span class="pl-k">@builtin</span> <span class="pl-s">&quot;whitespace.ne&quot;</span> <span class="pl-c"># `_` means arbitrary amount of whitespace</span>
+<span class="pl-k">@builtin</span> <span class="pl-s">&quot;number.ne&quot;</span>     <span class="pl-c"># `int`, `decimal`, and `percentage` number primitives</span>
+<span class="pl-en">csscolor</span> <span class="pl-k">-&gt;</span> <span class="pl-s">&quot;#&quot;</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span>
+          <span class="pl-k">|</span> <span class="pl-s">&quot;#&quot;</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span> <span class="pl-en">hexdigit</span>
+          <span class="pl-k">|</span> <span class="pl-s">&quot;rgb&quot;</span>  <span class="pl-en">_</span> <span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span>
+          <span class="pl-k">|</span> <span class="pl-s">&quot;hsl&quot;</span>  <span class="pl-en">_</span> <span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span>
+          <span class="pl-k">|</span> <span class="pl-s">&quot;rgba&quot;</span> <span class="pl-en">_</span> <span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">decimal</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span>
+          <span class="pl-k">|</span> <span class="pl-s">&quot;hsla&quot;</span> <span class="pl-en">_</span> <span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">decimal</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span>
+<span class="pl-en">hexdigit</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[a-fA-F0-9]</span>
+<span class="pl-en">colnum</span>   <span class="pl-k">-&gt;</span> <span class="pl-en">int</span> <span class="pl-k">|</span> <span class="pl-en">percentage</span></pre></div>
 </li>
-<li>Compile your grammar:<pre><code class="lang-bash">$ nearleyc csscolor.ne -o csscolor.js
-</code></pre>
+<li>Compile your grammar:
+<div class="highlight highlight-source-shell"><pre>$ nearleyc csscolor.ne -o csscolor.js</pre></div>
 </li>
-<li>Test your grammar:<pre><code class="lang-bash">$ nearley-test -i &quot;#00ff00&quot; csscolor.js
+<li>Test your grammar:
+<div class="highlight highlight-source-shell"><pre>$ nearley-test -i <span class="pl-s"><span class="pl-pds">&quot;</span>#00ff00<span class="pl-pds">&quot;</span></span> csscolor.js
 Parse results:
-[ [ &#39;#&#39;, [ &#39;0&#39; ], [ &#39;0&#39; ], [ &#39;f&#39; ], [ &#39;f&#39; ], [ &#39;0&#39; ], [ &#39;0&#39; ] ] ]
-</code></pre>
+[ [ <span class="pl-s"><span class="pl-pds">&apos;</span>#<span class="pl-pds">&apos;</span></span>, [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>f<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>f<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ] ] ]</pre></div>
 </li>
-<li>Turn your grammar into a generator:<pre><code class="lang-bash">$ nearley-unparse -n 3 csscolor.js
-</code></pre>
+<li>Turn your grammar into a generator:
+<div class="highlight highlight-source-shell"><pre>$ nearley-unparse -n 3 csscolor.js</pre></div>
 <pre><code>#Ab21F2
 rgb  ( -29.889%,7,8172)
 #a40
-</code></pre></li>
-<li>You try it! Type a CSS color here:
-<input type="text" id="parse-input" placeholder="rgba(0, 255, 0, 0.5)" /><pre><code id="parse-output">…and the parsed output will appear here!</code></pre></li>
-<li>Create beautiful railroad diagrams to document your grammar formally.<pre><code class="lang-bash">$ nearley-railroad csscolor.ne -o csscolor.html
 </code></pre>
+</li>
+<li>You try it! Type a CSS color here:
+<div id="user-content-sample-parse"></div>
+</li>
+<li>Create beautiful railroad diagrams to document your grammar formally.
+<div class="highlight highlight-source-shell"><pre>$ nearley-railroad csscolor.ne -o csscolor.html</pre></div>
 See a demo <a href="/www/railroad-demo">here</a>.</li>
 </ol>
-<h3 id="features">Features</h3>
+<h3 id="features">
+Features</h3>
 <ul>
 <li>nearley is the first JS parser to use the <strong>Earley</strong> algorithm (insert your
-own ‘early bird’ pun here). It also implements Joop Leo’s optimizations for
+own &#x2018;early bird&#x2019; pun here). It also implements Joop Leo&apos;s optimizations for
 right-recursion, making it effectively <strong>linear-time</strong> for LL(k) grammars.</li>
-<li>nearley lives happily in <strong>node</strong>, but doesn’t mind the <strong>browser</strong>.</li>
+<li>nearley lives happily in <strong>node</strong>, but doesn&apos;t mind the <strong>browser</strong>.</li>
 <li>nearley outputs <strong>small</strong> files. And its <strong>expressive</strong> DSL comes with
 plenty of <strong>syntactic sugar</strong> to keep your source files short. And sweet.</li>
-<li>nearley’s grammar language is powerful and expressive: you can use
+<li>nearley&apos;s grammar language is powerful and expressive: you can use
 <strong>macros</strong>, import from a large <strong>builtin library</strong> of pre-defined
 parser-pieces, use a <strong>tokenizer</strong> for extra performance, and more!</li>
 <li>nearley is built on an idiomatic <strong>streaming API</strong>. You even have access to
@@ -341,7 +351,8 @@ all the parsings (in a deterministic order!).</li>
 catches a parse-time error, nearley tells you exactly what went wrong and
 where.</li>
 <li>nearley is powerful enough to be <strong>bootstrapped</strong>. That means nearley uses
-nearley to compile parts of nearley. <em>nearleyception!</em></li>
+nearley to compile parts of nearley. <em>nearleyception!</em>
+</li>
 <li>nearley parsers can be inverted to form <strong>generators</strong> which output random
 strings that match a grammar. Useful for writing <strong>test cases</strong>,
 <strong>fuzzers</strong>, and <strong>Mad-Libs</strong>.</li>
@@ -351,7 +362,8 @@ easy-to-understand documentation of your grammar.</li>
 <strong>vim</strong>, <strong>Sublime Text</strong>, <strong>Atom</strong>, and <strong>VS Code</strong>; there are also
 plug-ins for <strong>Webpack</strong> and <strong>gulp</strong>.</li>
 </ul>
-<h3 id="projects-using-nearley">Projects using nearley</h3>
+<h3 id="projects-using-nearley">
+Projects using nearley</h3>
 <p><strong>Artificial Intelligence and NLP</strong>:
 <a href="https://github.com/ChalmersGU-AI-course/shrdlite-course-project">Shrdlite</a> is
 a programming project in Artificial Intelligence, a course given at the
@@ -367,7 +379,7 @@ BibTeX-to-HTML converter,
 <a href="https://github.com/fiduswriter/biblatex-csl-converter">biblatex-csl-converter</a>
 converts between bibtex/CSL/JSON, <a href="https://github.com/gajus/scalpel">scalpel</a>
 parses CSS selectors (powering <a href="https://github.com/airbnb/enzyme">enzyme</a>,
-Airbnb’s React testing tool),
+Airbnb&apos;s React testing tool),
 <a href="https://github.com/waratuman/rfc5545-rrule">rfc5545-rrule</a> helps parse
 iCalendar data, <a href="https://github.com/mangudai/mangudai">mangudai</a> parses RMS
 scripts for Age of Empires II, <a href="https://github.com/r24y/tf-hcl">tf-hcl</a> parses
@@ -396,7 +408,7 @@ programming language, <a href="https://github.com/farskipper/ecmaless">ecmaless<
 easily-extensible language, <a href="https://github.com/xodio/hm-parser">hm-parser</a>
 parses Haskell-like Hindley-Milner type signatures,
 <a href="https://github.com/kozily/web">kozily</a> implements the Oz language,
-<a href="https://stefan1niculae.github.io/abstract-machine/">abstract-machine</a> inspects
+<a href="https://stefan1niculae.github.io/abstract-machine/" rel="nofollow">abstract-machine</a> inspects
 execution models, <a href="https://github.com/Malpaux/fbp-types">fbp-types</a> provides
 typechecking primitives for flow-based systems,
 <a href="https://github.com/sizigi/lp5562">lp5562</a> is an assembler for the TI LP5562
@@ -408,9 +420,9 @@ systems.</p>
 <p><strong>Mathematics</strong>: <a href="https://github.com/andrejewski/solvent">Solvent</a> is a
 powerful desktop calculator,
 <a href="https://github.com/andrejewski/truth-table">Truth-table</a> is a tool to
-visualize propositional logic in truth tables, <a href="http://emunotes.com">Emunotes</a>
+visualize propositional logic in truth tables, <a href="http://emunotes.com" rel="nofollow">Emunotes</a>
 is a personal Wiki with inline graphing and computation,
-<a href="https://kgram.github.io/react-equation/">react-equation</a> parses and renders
+<a href="https://kgram.github.io/react-equation/" rel="nofollow">react-equation</a> parses and renders
 equations in React, <a href="https://github.com/cemulate/the-mlab">the mLab</a> generates
 category theory papers.</p>
 <p><strong>Domain-specific languages</strong>: <a href="https://github.com/jcorbin/hexant">Hexant</a> is a
@@ -421,7 +433,7 @@ create board games, <a href="https://github.com/danigb/in-seconds">in-seconds</a
 time calculator for music applications,
 <a href="https://github.com/bumbu/website-spec">website-spec</a> is a tool for functional
 web testing, <a href="https://github.com/gajus/pianola">pianola</a> allows declarative
-function composition, <a href="https://idyll-lang.github.io/idyll/">idyll</a> is a markup
+function composition, <a href="https://idyll-lang.github.io/idyll/" rel="nofollow">idyll</a> is a markup
 language for data-driven documents,
 <a href="https://github.com/affinipay/virtsecgroup">virtsecgroup</a> provides virtual AWS
 security groups, <a href="https://github.com/Pwootage/deadfad">deadfad</a> is a hex editor
@@ -435,88 +447,110 @@ provides syntactic grep for JavaScript,
 <a href="https://github.com/monostable/electro-grammar">electro-grammar</a> parses
 descriptions of electronic components like resistors and capacitors,
 <a href="https://github.com/accordproject">cicero</a> helps create smart legal contracts.</p>
-<p><strong>Parsing libraries</strong>: <a href="http://nearley.js.org">nearley</a> is a parser toolkit for
+<p><strong>Parsing libraries</strong>: <a href="http://nearley.js.org" rel="nofollow">nearley</a> is a parser toolkit for
 JavaScript. It has a nearley-based DSL to specify parsers.</p>
-<!--Excited? Get started on [Github](https://github.com/Hardmath123/nearley),
-visit us on [npm](http://npmjs.org/package/nearley), explore nearley in your
-browser on the [playground](https://omrelli.ug/nearley-playground/), or try out
-the [calculator demo](examples/calculator/) for more action.-->
-<h3 id="give-to-nearley">Give to nearley</h3>
-<p>nearley has been maintained by volunteers since 2014. If you want to help
-support us, contact <strong>@kach</strong> or <strong>@tjvr</strong> on GitHub. We’ll send over our
-PayPal information – and maybe something nice. :-).</p>
 
+<h3 id="give-to-nearley">
+Give to nearley</h3>
+<p>nearley has been maintained by volunteers since 2014. If you want to help
+support us, contact <strong>@kach</strong> or <strong>@tjvr</strong> on GitHub. We&apos;ll send over our
+PayPal information -- and maybe something nice. :-).</p>
+</body></html>
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
     href="http://hardmath123.github.io">Hardmath123</a> (<a
     href="http://github.com/Hardmath123">Github</a>). You're welcome to
     leave questions, comments, advice, or ideas as Github issues. And
     feel free to fork nearley with your own experiments!<br/>
-    
+
     <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
     <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
 </div>
 
-<script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>
-document.querySelector('#highlight-js').addEventListener('load', function() {
-    [].slice.apply(document.querySelectorAll('pre code')).forEach(function(b) {
-        hljs.highlightBlock(b)
-    })
-})
-</script>
-
 <script charset="utf-8" src="/lib/nearley.js"></script>
 <script charset="utf-8" src="/examples/js/csscolor.js"></script>
 <script type="text/javascript">
-window.addEventListener('load', function() {
-    document.getElementById('parse-input').addEventListener('keyup', function() {
+window.addEventListener(
+  "load",
+  function() {
+    document.getElementById("user-content-sample-parse").innerHTML =
+      '<input type="text" id="parse-input" placeholder="rgba(0, 255, 0, 0.5)" />\n\
+<pre><code id="parse-output">…and the parsed output will appear here!</code></pre>';
+    document.getElementById("parse-input").addEventListener(
+      "keyup",
+      function() {
         // $ ./bin/nearleyc.js examples/csscolor.ne -o examples/js/csscolor.js
         var str = this.value;
-        var parser = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
+        var parser = new nearley.Parser(
+          grammar.ParserRules,
+          grammar.ParserStart
+        );
         try {
-            parser.feed(str);
-            document.getElementById('parse-output').innerHTML = JSON.stringify(parser.results, null, 2);
-            this.style.color = "#559";
-        } catch(e) {
-            document.getElementById('parse-output').innerHTML = "";
-            this.style.color = "red";
+          parser.feed(str);
+          document.getElementById("parse-output").innerHTML = JSON.stringify(
+            parser.results,
+            null,
+            2
+          );
+          this.style.color = "#559";
+        } catch (e) {
+          document.getElementById("parse-output").innerHTML = "";
+          this.style.color = "red";
         }
-    }, false);
-}, false);
+      },
+      false
+    );
+  },
+  false
+);
 </script>
 
 <script>
-window.addEventListener('scroll', onScroll)
-window.addEventListener('resize', onScroll)
+window.addEventListener("scroll", onScroll);
+window.addEventListener("resize", onScroll);
 
-var timeout
+var timeout;
 function onScroll(e) {
-    if (timeout) clearTimeout(timeout)
-    timeout = setTimeout(scrollEnd, 50)
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(scrollEnd, 50);
 }
 
 function scrollEnd() {
-  var headings = document.querySelectorAll('h3')
-  var offset = 60
-  for (var i=headings.length; i--; ) {
-    var h3 = headings[i]
+  var headings = document.querySelectorAll("h3");
+  var offset = 60;
+  for (var i = headings.length; i--; ) {
+    var h3 = headings[i];
     if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector('.page-heading-active')
-      if (cur) cur.className = 'page-heading'
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
-      return
+      var cur = document.querySelector(".page-heading-active");
+      if (cur) cur.className = "page-heading";
+      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
+        "page-heading page-heading-active";
+      return;
     }
   }
 }
 </script>
 
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-46120535-5', 'auto');
-ga('send', 'pageview');
+(function(i, s, o, g, r, a, m) {
+  i["GoogleAnalyticsObject"] = r;
+  (i[r] =
+    i[r] ||
+    function() {
+      (i[r].q = i[r].q || []).push(arguments);
+    }),
+    (i[r].l = 1 * new Date());
+  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+  a.async = 1;
+  a.src = g;
+  m.parentNode.insertBefore(a, m);
+})(
+  window,
+  document,
+  "script",
+  "https://www.google-analytics.com/analytics.js",
+  "ga"
+);
+ga("create", "UA-46120535-5", "auto");
+ga("send", "pageview");
 </script>
-

--- a/index.html
+++ b/index.html
@@ -565,12 +565,12 @@ PayPal information – and maybe something nice. :-).</p>
     </script>
 
     <script>
-      (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-      ga('create', 'UA-46120535-5', 'auto');
-      ga('send', 'pageview');
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-46120535-5', 'auto');
+ga('send', 'pageview');
     </script>
+  </div>
+</body>

--- a/index.html
+++ b/index.html
@@ -241,8 +241,6 @@ nav ul a {
     }
 }
 
-/* highlight.js */
-
 .highlight pre {
   display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
 }
@@ -331,7 +329,7 @@ See a demo <a href="/www/railroad-demo">here</a>.</li>
 Features</h3>
 <ul>
 <li>nearley is the first JS parser to use the <strong>Earley</strong> algorithm (insert your
-own &#x2018;early bird&#x2019; pun here). It also implements Joop Leo&apos;s optimizations for
+own &#x2018;earley bird&#x2019; pun here). It also implements Joop Leo&apos;s optimizations for
 right-recursion, making it effectively <strong>linear-time</strong> for LL(k) grammars.</li>
 <li>nearley lives happily in <strong>node</strong>, but doesn&apos;t mind the <strong>browser</strong>.</li>
 <li>nearley outputs <strong>small</strong> files. And its <strong>expressive</strong> DSL comes with
@@ -532,25 +530,5 @@ function scrollEnd() {
 </script>
 
 <script>
-(function(i, s, o, g, r, a, m) {
-  i["GoogleAnalyticsObject"] = r;
-  (i[r] =
-    i[r] ||
-    function() {
-      (i[r].q = i[r].q || []).push(arguments);
-    }),
-    (i[r].l = 1 * new Date());
-  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-  a.async = 1;
-  a.src = g;
-  m.parentNode.insertBefore(a, m);
-})(
-  window,
-  document,
-  "script",
-  "https://www.google-analytics.com/analytics.js",
-  "ga"
-);
-ga("create", "UA-46120535-5", "auto");
-ga("send", "pageview");
+(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
 </script>

--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <title>Home - nearley.js - JS Parsing Toolkit</title>
-<meta charset="utf-8"/>
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
 <style>
-@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
+  @import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -145,11 +145,23 @@ code {
 
 pre code, .highlight pre {
     border-radius: 0.5em;
-    padding: 0.5em;
+    margin: 5px;
+    padding: 10px;
     display: block;
     overflow: auto;
 }
 
+.highlight pre {
+    padding: 0;
+    margin: 0;
+    display: block;
+    overflow-x: auto;
+}
+
+pre > code > pre > code {
+    padding: 0;
+    margin: 0;
+}
 
 ol {
     counter-reset: tutorial-counter;
@@ -206,7 +218,7 @@ nav ul a {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 0.25em 0.5em; */
+    padding: 0.25em 0.5em;
 }
 .page {
     display: block;
@@ -241,56 +253,105 @@ nav ul a {
     }
 }
 
-.highlight pre {
-  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+code pre {
+    margin: 0;
 }
-
 </style>
 
-<body class="docs-page">
+<body class="docs-page" >
 
-<a href="https://github.com/kach/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-<nav id="nav">
-    <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">2.12.1</span></a></h1>
+  <a href="https://github.com/kach/nearley" class="github-corner">
+    <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+      <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+      <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+        fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+      <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+        fill="currentColor" class="octo-body"></path>
+    </svg>
+  </a>
+  <style>
+    .github-corner:hover .octo-arm {
+      animation: octocat-wave 560ms ease-in-out
+    }
+
+    @keyframes octocat-wave {
+      0%,
+      100% {
+        transform: rotate(0)
+      }
+      20%,
+      60% {
+        transform: rotate(-25deg)
+      }
+      40%,
+      80% {
+        transform: rotate(10deg)
+      }
+    }
+
+    @media (max-width:500px) {
+      .github-corner:hover .octo-arm {
+        animation: none
+      }
+      .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out
+      }
+    }
+  </style>
+  <nav id="nav">
+    <h1>
+      <a href="/">nearley
+        <span style="color: #559;">.js</span>
+        <span id="version">2.12.1</span>
+      </a>
+    </h1>
     <ul>
-        <li class="page">
-            <a href="#" class="page-title-active">Home</a>
-            <ul>
-                <li class="page-heading"><a href="#nearley-101">
-nearley 101</a></li>
-                <li class="page-heading"><a href="#features">
-Features</a></li>
-                <li class="page-heading"><a href="#projects-using-nearley">
-Projects using nearley</a></li>
-                <li class="page-heading"><a href="#give-to-nearley">
-Give to nearley</a></li>
-            </ul>
+       
+      <li class="page">
+        <a href="#" class="page-title-active">Home</a>
+        <ul>
+          <li class="page-heading">
+            <a href="#nearley-101">nearley 101</a>
+          <li class="page-heading">
+            <a href="#features">Features</a>
+          <li class="page-heading">
+            <a href="#projects-using-nearley">Projects using nearley</a>
+          <li class="page-heading">
+            <a href="#give-to-nearley">Give to nearley</a>
+        </ul>
         </li>
-        <li class="page"><a href="/docs/getting-started">Getting started</a>
-        <li class="page"><a href="/docs/grammar">Writing a parser</a>
-        <li class="page"><a href="/docs/parser">Using a parser</a>
-        <li class="page"><a href="/docs/tokenizers">Tokenizers</a>
-        <li class="page"><a href="/docs/tooling">Tooling</a>
-        <li class="page"><a href="/docs/how-to-grammar-good">How to grammar good</a>
-        <li class="page"><a href="/docs/using-in-frontend">Compiling in browsers</a>
-        <li class="page"><a href="/docs/glossary">Glossary</a>
+          <li class="page">
+          <a href="/docs/getting-started">Getting started</a>
+                    <li class="page">
+          <a href="/docs/grammar">Writing a parser</a>
+                    <li class="page">
+          <a href="/docs/parser">Using a parser</a>
+                    <li class="page">
+          <a href="/docs/tokenizers">Tokenizers</a>
+                    <li class="page">
+          <a href="/docs/tooling">Tooling</a>
+                    <li class="page">
+          <a href="/docs/how-to-grammar-good">How to grammar good</a>
+                    <li class="page">
+          <a href="/docs/using-in-frontend">Compiling in browsers</a>
+                    <li class="page">
+          <a href="/docs/glossary">Glossary</a>
+           
     </ul>
-</nav>
+  </nav>
 
-<div id="main" class="center">
+  <div id="main" class="center">
 
-<h2>Home</h2>
-<html><head></head><body><p><strong>Parsers</strong> turn strings of characters into meaningful data structures (like a
+    <h2>Home</h2>
+    <p><strong>Parsers</strong> turn strings of characters into meaningful data structures (like a
 JSON object!). <strong>nearley</strong> is a <strong>fast</strong>, <strong>feature-rich</strong>, and <strong>modern</strong>
 parser toolkit for JavaScript. nearley is an <a href="https://github.com/npm/npm-collection-staff-picks">npm Staff
 Pick</a>.</p>
-<h3 id="nearley-101">
-nearley 101</h3>
+<h3 id="nearley-101">nearley 101</h3>
 <ol>
 <li>Install: <code>$ npm install -g nearley</code> (or try nearley live in your browser
-<a href="https://omrelli.ug/nearley-playground/" rel="nofollow">here</a>!)</li>
-<li>Write your grammar:
-<div class="highlight highlight-source-ne"><pre><span class="pl-c"># Match a CSS color</span>
+<a href="https://omrelli.ug/nearley-playground/">here</a>!)</li>
+<li>Write your grammar:<pre><code class="language-ne"><div class="highlight highlight-source-ne"><pre><span class="pl-c"># Match a CSS color</span>
 <span class="pl-c"># http://www.w3.org/TR/css3-color/#colorunits</span>
 <span class="pl-k">@builtin</span> <span class="pl-s">&quot;whitespace.ne&quot;</span> <span class="pl-c"># `_` means arbitrary amount of whitespace</span>
 <span class="pl-k">@builtin</span> <span class="pl-s">&quot;number.ne&quot;</span>     <span class="pl-c"># `int`, `decimal`, and `percentage` number primitives</span>
@@ -301,40 +362,33 @@ nearley 101</h3>
           <span class="pl-k">|</span> <span class="pl-s">&quot;rgba&quot;</span> <span class="pl-en">_</span> <span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">decimal</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span>
           <span class="pl-k">|</span> <span class="pl-s">&quot;hsla&quot;</span> <span class="pl-en">_</span> <span class="pl-s">&quot;(&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">colnum</span> <span class="pl-en">_</span> <span class="pl-s">&quot;,&quot;</span> <span class="pl-en">_</span> <span class="pl-en">decimal</span> <span class="pl-en">_</span> <span class="pl-s">&quot;)&quot;</span>
 <span class="pl-en">hexdigit</span> <span class="pl-k">-&gt;</span> <span class="pl-s">[a-fA-F0-9]</span>
-<span class="pl-en">colnum</span>   <span class="pl-k">-&gt;</span> <span class="pl-en">int</span> <span class="pl-k">|</span> <span class="pl-en">percentage</span></pre></div>
+<span class="pl-en">colnum</span>   <span class="pl-k">-&gt;</span> <span class="pl-en">int</span> <span class="pl-k">|</span> <span class="pl-en">percentage</span></pre></div></code></pre>
 </li>
-<li>Compile your grammar:
-<div class="highlight highlight-source-shell"><pre>$ nearleyc csscolor.ne -o csscolor.js</pre></div>
+<li>Compile your grammar:<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ nearleyc csscolor.ne -o csscolor.js</pre></div></code></pre>
 </li>
-<li>Test your grammar:
-<div class="highlight highlight-source-shell"><pre>$ nearley-test -i <span class="pl-s"><span class="pl-pds">&quot;</span>#00ff00<span class="pl-pds">&quot;</span></span> csscolor.js
+<li>Test your grammar:<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ nearley-test -i <span class="pl-s"><span class="pl-pds">&quot;</span>#00ff00<span class="pl-pds">&quot;</span></span> csscolor.js
 Parse results:
-[ [ <span class="pl-s"><span class="pl-pds">&apos;</span>#<span class="pl-pds">&apos;</span></span>, [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>f<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>f<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ] ] ]</pre></div>
+[ [ <span class="pl-s"><span class="pl-pds">&apos;</span>#<span class="pl-pds">&apos;</span></span>, [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>f<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>f<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ], [ <span class="pl-s"><span class="pl-pds">&apos;</span>0<span class="pl-pds">&apos;</span></span> ] ] ]</pre></div></code></pre>
 </li>
-<li>Turn your grammar into a generator:
-<div class="highlight highlight-source-shell"><pre>$ nearley-unparse -n 3 csscolor.js</pre></div>
-<pre><code>#Ab21F2
+<li>Turn your grammar into a generator:<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ nearley-unparse -n 3 csscolor.js</pre></div></code></pre>
+<pre><code><pre><code>#Ab21F2
 rgb  ( -29.889%,7,8172)
 #a40
-</code></pre>
-</li>
-<li>You try it! Type a CSS color here:
-<div id="user-content-sample-parse"></div>
-</li>
-<li>Create beautiful railroad diagrams to document your grammar formally.
-<div class="highlight highlight-source-shell"><pre>$ nearley-railroad csscolor.ne -o csscolor.html</pre></div>
+</code></pre></code></pre></li>
+<li>You try it! Type a CSS color here: <input type="text" id="parse-input" placeholder="rgba(0, 255, 0, 0.5)" />
+<pre><code id="parse-output">…and the parsed output will appear here!</code></pre></li>
+<li>Create beautiful railroad diagrams to document your grammar formally.<pre><code class="language-bash"><div class="highlight highlight-source-shell"><pre>$ nearley-railroad csscolor.ne -o csscolor.html</pre></div></code></pre>
 See a demo <a href="/www/railroad-demo">here</a>.</li>
 </ol>
-<h3 id="features">
-Features</h3>
+<h3 id="features">Features</h3>
 <ul>
 <li>nearley is the first JS parser to use the <strong>Earley</strong> algorithm (insert your
-own &#x2018;earley bird&#x2019; pun here). It also implements Joop Leo&apos;s optimizations for
+own ‘earley bird’ pun here). It also implements Joop Leo’s optimizations for
 right-recursion, making it effectively <strong>linear-time</strong> for LL(k) grammars.</li>
-<li>nearley lives happily in <strong>node</strong>, but doesn&apos;t mind the <strong>browser</strong>.</li>
+<li>nearley lives happily in <strong>node</strong>, but doesn’t mind the <strong>browser</strong>.</li>
 <li>nearley outputs <strong>small</strong> files. And its <strong>expressive</strong> DSL comes with
 plenty of <strong>syntactic sugar</strong> to keep your source files short. And sweet.</li>
-<li>nearley&apos;s grammar language is powerful and expressive: you can use
+<li>nearley’s grammar language is powerful and expressive: you can use
 <strong>macros</strong>, import from a large <strong>builtin library</strong> of pre-defined
 parser-pieces, use a <strong>tokenizer</strong> for extra performance, and more!</li>
 <li>nearley is built on an idiomatic <strong>streaming API</strong>. You even have access to
@@ -349,8 +403,7 @@ all the parsings (in a deterministic order!).</li>
 catches a parse-time error, nearley tells you exactly what went wrong and
 where.</li>
 <li>nearley is powerful enough to be <strong>bootstrapped</strong>. That means nearley uses
-nearley to compile parts of nearley. <em>nearleyception!</em>
-</li>
+nearley to compile parts of nearley. <em>nearleyception!</em></li>
 <li>nearley parsers can be inverted to form <strong>generators</strong> which output random
 strings that match a grammar. Useful for writing <strong>test cases</strong>,
 <strong>fuzzers</strong>, and <strong>Mad-Libs</strong>.</li>
@@ -360,8 +413,7 @@ easy-to-understand documentation of your grammar.</li>
 <strong>vim</strong>, <strong>Sublime Text</strong>, <strong>Atom</strong>, and <strong>VS Code</strong>; there are also
 plug-ins for <strong>Webpack</strong> and <strong>gulp</strong>.</li>
 </ul>
-<h3 id="projects-using-nearley">
-Projects using nearley</h3>
+<h3 id="projects-using-nearley">Projects using nearley</h3>
 <p><strong>Artificial Intelligence and NLP</strong>:
 <a href="https://github.com/ChalmersGU-AI-course/shrdlite-course-project">Shrdlite</a> is
 a programming project in Artificial Intelligence, a course given at the
@@ -377,7 +429,7 @@ BibTeX-to-HTML converter,
 <a href="https://github.com/fiduswriter/biblatex-csl-converter">biblatex-csl-converter</a>
 converts between bibtex/CSL/JSON, <a href="https://github.com/gajus/scalpel">scalpel</a>
 parses CSS selectors (powering <a href="https://github.com/airbnb/enzyme">enzyme</a>,
-Airbnb&apos;s React testing tool),
+Airbnb’s React testing tool),
 <a href="https://github.com/waratuman/rfc5545-rrule">rfc5545-rrule</a> helps parse
 iCalendar data, <a href="https://github.com/mangudai/mangudai">mangudai</a> parses RMS
 scripts for Age of Empires II, <a href="https://github.com/r24y/tf-hcl">tf-hcl</a> parses
@@ -406,7 +458,7 @@ programming language, <a href="https://github.com/farskipper/ecmaless">ecmaless<
 easily-extensible language, <a href="https://github.com/xodio/hm-parser">hm-parser</a>
 parses Haskell-like Hindley-Milner type signatures,
 <a href="https://github.com/kozily/web">kozily</a> implements the Oz language,
-<a href="https://stefan1niculae.github.io/abstract-machine/" rel="nofollow">abstract-machine</a> inspects
+<a href="https://stefan1niculae.github.io/abstract-machine/">abstract-machine</a> inspects
 execution models, <a href="https://github.com/Malpaux/fbp-types">fbp-types</a> provides
 typechecking primitives for flow-based systems,
 <a href="https://github.com/sizigi/lp5562">lp5562</a> is an assembler for the TI LP5562
@@ -418,9 +470,9 @@ systems.</p>
 <p><strong>Mathematics</strong>: <a href="https://github.com/andrejewski/solvent">Solvent</a> is a
 powerful desktop calculator,
 <a href="https://github.com/andrejewski/truth-table">Truth-table</a> is a tool to
-visualize propositional logic in truth tables, <a href="http://emunotes.com" rel="nofollow">Emunotes</a>
+visualize propositional logic in truth tables, <a href="http://emunotes.com">Emunotes</a>
 is a personal Wiki with inline graphing and computation,
-<a href="https://kgram.github.io/react-equation/" rel="nofollow">react-equation</a> parses and renders
+<a href="https://kgram.github.io/react-equation/">react-equation</a> parses and renders
 equations in React, <a href="https://github.com/cemulate/the-mlab">the mLab</a> generates
 category theory papers.</p>
 <p><strong>Domain-specific languages</strong>: <a href="https://github.com/jcorbin/hexant">Hexant</a> is a
@@ -431,7 +483,7 @@ create board games, <a href="https://github.com/danigb/in-seconds">in-seconds</a
 time calculator for music applications,
 <a href="https://github.com/bumbu/website-spec">website-spec</a> is a tool for functional
 web testing, <a href="https://github.com/gajus/pianola">pianola</a> allows declarative
-function composition, <a href="https://idyll-lang.github.io/idyll/" rel="nofollow">idyll</a> is a markup
+function composition, <a href="https://idyll-lang.github.io/idyll/">idyll</a> is a markup
 language for data-driven documents,
 <a href="https://github.com/affinipay/virtsecgroup">virtsecgroup</a> provides virtual AWS
 security groups, <a href="https://github.com/Pwootage/deadfad">deadfad</a> is a hex editor
@@ -445,90 +497,80 @@ provides syntactic grep for JavaScript,
 <a href="https://github.com/monostable/electro-grammar">electro-grammar</a> parses
 descriptions of electronic components like resistors and capacitors,
 <a href="https://github.com/accordproject">cicero</a> helps create smart legal contracts.</p>
-<p><strong>Parsing libraries</strong>: <a href="http://nearley.js.org" rel="nofollow">nearley</a> is a parser toolkit for
+<p><strong>Parsing libraries</strong>: <a href="http://nearley.js.org">nearley</a> is a parser toolkit for
 JavaScript. It has a nearley-based DSL to specify parsers.</p>
+<!--Excited? Get started on [Github](https://github.com/Hardmath123/nearley),
+visit us on [npm](http://npmjs.org/package/nearley), explore nearley in your
+browser on the [playground](https://omrelli.ug/nearley-playground/), or try out
+the [calculator demo](examples/calculator/) for more action.-->
 
-<h3 id="give-to-nearley">
-Give to nearley</h3>
+<h3 id="give-to-nearley">Give to nearley</h3>
 <p>nearley has been maintained by volunteers since 2014. If you want to help
-support us, contact <strong>@kach</strong> or <strong>@tjvr</strong> on GitHub. We&apos;ll send over our
-PayPal information -- and maybe something nice. :-).</p>
-</body></html>
+support us, contact <strong>@kach</strong> or <strong>@tjvr</strong> on GitHub. We’ll send over our
+PayPal information – and maybe something nice. :-).</p>
 
-    <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a
-    href="http://hardmath123.github.io">Hardmath123</a> (<a
-    href="http://github.com/Hardmath123">Github</a>). You're welcome to
-    leave questions, comments, advice, or ideas as Github issues. And
-    feel free to fork nearley with your own experiments!<br/>
 
-    <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
-    <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
-</div>
+    <div id="footer">
+      <p>nearley is MIT-licensed. It's maintained by
+        <a href="http://hardmath123.github.io">Hardmath123</a> (
+        <a href="http://github.com/Hardmath123">Github</a>). You're welcome to leave questions, comments, advice, or ideas as Github issues. And feel free to fork
+        nearley with your own experiments!
+        <br/>
 
-<script charset="utf-8" src="/lib/nearley.js"></script>
-<script charset="utf-8" src="/examples/js/csscolor.js"></script>
-<script type="text/javascript">
-window.addEventListener(
-  "load",
-  function() {
-    document.getElementById("user-content-sample-parse").innerHTML =
-      '<input type="text" id="parse-input" placeholder="rgba(0, 255, 0, 0.5)" />\n\
-<pre><code id="parse-output">…and the parsed output will appear here!</code></pre>';
-    document.getElementById("parse-input").addEventListener(
-      "keyup",
-      function() {
-        // $ ./bin/nearleyc.js examples/csscolor.ne -o examples/js/csscolor.js
-        var str = this.value;
-        var parser = new nearley.Parser(
-          grammar.ParserRules,
-          grammar.ParserStart
-        );
-        try {
-          parser.feed(str);
-          document.getElementById("parse-output").innerHTML = JSON.stringify(
-            parser.results,
-            null,
-            2
-          );
-          this.style.color = "#559";
-        } catch (e) {
-          document.getElementById("parse-output").innerHTML = "";
-          this.style.color = "red";
+        <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
+          <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo" />
+        </a>
+    </div>
+    <script charset="utf-8" src="/lib/nearley.js"></script>
+    <script charset="utf-8" src="/examples/js/csscolor.js"></script>
+    <script type="text/javascript">
+      window.addEventListener('load', function () {
+        document.getElementById('parse-input').addEventListener('keyup', function () {
+          // $ ./bin/nearleyc.js examples/csscolor.ne -o examples/js/csscolor.js
+          var str = this.value;
+          var parser = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
+          try {
+            parser.feed(str);
+            document.getElementById('parse-output').innerHTML = JSON.stringify(parser.results, null, 2);
+            this.style.color = "#559";
+          } catch (e) {
+            document.getElementById('parse-output').innerHTML = "";
+            this.style.color = "red";
+          }
+        }, false);
+      }, false);
+    </script>
+
+    <script>
+      window.addEventListener('scroll', onScroll)
+      window.addEventListener('resize', onScroll)
+      var timeout
+      function onScroll(e) {
+        if (timeout) clearTimeout(timeout)
+        timeout = setTimeout(scrollEnd, 50)
+      }
+      function scrollEnd() {
+        var headings = document.querySelectorAll('h3')
+        var offset = 60
+        for (var i = headings.length; i--;) {
+          var h3 = headings[i]
+          if (h3.offsetTop < window.scrollY + offset) {
+            var cur = document.querySelector('.page-heading-active')
+            if (cur) cur.className = 'page-heading'
+            document.querySelector('a[href="#' + h3.id + '"]').parentNode.className = 'page-heading page-heading-active'
+            return
+          }
         }
-      },
-      false
-    );
-  },
-  false
-);
-</script>
+      }
+    </script>
 
-<script>
-window.addEventListener("scroll", onScroll);
-window.addEventListener("resize", onScroll);
-
-var timeout;
-function onScroll(e) {
-  if (timeout) clearTimeout(timeout);
-  timeout = setTimeout(scrollEnd, 50);
-}
-
-function scrollEnd() {
-  var headings = document.querySelectorAll("h3");
-  var offset = 60;
-  for (var i = headings.length; i--; ) {
-    var h3 = headings[i];
-    if (h3.offsetTop < window.scrollY + offset) {
-      var cur = document.querySelector(".page-heading-active");
-      if (cur) cur.className = "page-heading";
-      document.querySelector('a[href="#' + h3.id + '"]').parentNode.className =
-        "page-heading page-heading-active";
-      return;
-    }
-  }
-}
-</script>
-
-<script>
-(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date;a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");ga("create","UA-46120535-5","auto");ga("send","pageview");
-</script>
+    <script>
+      (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-46120535-5', 'auto');
+      ga('send', 'pageview');
+    </script>

--- a/www/main.css
+++ b/www/main.css
@@ -235,8 +235,6 @@ nav ul a {
     }
 }
 
-/* highlight.js */
-
 .highlight pre {
   display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
 }

--- a/www/main.css
+++ b/www/main.css
@@ -139,11 +139,23 @@ code {
 
 pre code, .highlight pre {
     border-radius: 0.5em;
-    padding: 0.5em;
+    margin: 5px;
+    padding: 10px;
     display: block;
     overflow: auto;
 }
 
+.highlight pre {
+    padding: 0;
+    margin: 0;
+    display: block;
+    overflow-x: auto;
+}
+
+pre > code > pre > code {
+    padding: 0;
+    margin: 0;
+}
 
 ol {
     counter-reset: tutorial-counter;
@@ -200,7 +212,7 @@ nav ul a {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 0.25em 0.5em; */
+    padding: 0.25em 0.5em;
 }
 .page {
     display: block;
@@ -235,6 +247,6 @@ nav ul a {
     }
 }
 
-.highlight pre {
-  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+code pre {
+    margin: 0;
 }

--- a/www/main.css
+++ b/www/main.css
@@ -1,3 +1,4 @@
+@import "https://cdn.jsdelivr.net/npm/github-syntax-light/lib/github-light.css";
 body {
     font-family: BlinkMacSystemFont, -apple-system, Helvetica Neue, Open Sans, Ubuntu, Arial, Helvetica, sans-serif;
     font-weight: 300;
@@ -136,7 +137,7 @@ code {
     background-color: #eee;
 }
 
-pre code {
+pre code, .highlight pre {
     border-radius: 0.5em;
     padding: 0.5em;
     display: block;
@@ -236,5 +237,6 @@ nav ul a {
 
 /* highlight.js */
 
-.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
-
+.highlight pre {
+  display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0
+}


### PR DESCRIPTION
This resolves #351.

I switched the markdown parser to the Github Flavored Markdown API, so nearley grammar works with it. If you want to change the syntax theme, you can change the `@import` in the CSS to something generated from [here](https://github.com/primer/github-syntax-theme-generator). It doesn't support smartypants, so hopefully that's not too important.

The only other change is that if you wanted to include something else that's interactive, like on the home page, you'd have to implement it through JS in the template layout, as GFM parses out "dangerous tags" like input. See line 58 in template.html for what I did.