### PR TITLE
shorten rule strings to reduce minified code size

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -75,13 +75,31 @@
         } else if (s.token) {
             return s.token;
         } else {
-            return JSON.stringify(s);
+            return toCommentedShortName(s);
+        }
+    }
+
+    var lookup = {}
+    var counter = 0
+    function shortenName(name) {
+        if (!lookup[name]) {
+            var str = '' + counter++
+            lookup[name] = str
+        }
+        return lookup[name]
+    }
+
+    function toCommentedShortName(name) {
+        if (typeof name === 'string') {
+            return JSON.stringify(shortenName(name)) + "/*" + name + "*/"
+        } else {
+            return JSON.stringify(name)
         }
     }
 
     function serializeRule(rule, builtinPostprocessors) {
         var ret = '{';
-        ret += '"name": ' + JSON.stringify(rule.name);
+        ret += '"name": ' + toCommentedShortName((rule.name));
         ret += ', "symbols": [' + rule.symbols.map(serializeSymbol).join(', ') + ']';
         if (rule.postprocess) {
             if(rule.postprocess.builtin) {
@@ -116,7 +134,7 @@
         output += "    ParserRules: " +
             serializeRules(parser.rules, generate.javascript.builtinPostprocessors)
             + "\n";
-        output += "  , ParserStart: " + JSON.stringify(parser.start) + "\n";
+        output += "  , ParserStart: " + toCommentedShortName((parser.start)) + "\n";
         output += "}\n";
         output += "if (typeof module !== 'undefined'"
             + "&& typeof module.exports !== 'undefined') {\n";
@@ -142,7 +160,7 @@
         output += parser.body.join('\n');
         output += "let Lexer = " + parser.config.lexer + ";\n";
         output += "let ParserRules = " + serializeRules(parser.rules, generate.javascript.builtinPostprocessors) + ";\n";
-        output += "let ParserStart = " + JSON.stringify(parser.start) + ";\n";
+        output += "let ParserStart = " + toCommentedShortName((parser.start)) + ";\n";
         output += "export default { Lexer, ParserRules, ParserStart };\n";
         return output;
     };
@@ -161,7 +179,7 @@
                     '      ',
                     {indentFirst: false})
         + ",\n";
-        output += "    ParserStart: " + JSON.stringify(parser.start) + "\n";
+        output += "    ParserStart: " + toCommentedShortName((parser.start)) + "\n";
         output += "  }\n";
         output += "  if typeof module != 'undefined' "
             + "&& typeof module.exports != 'undefined'\n";
@@ -209,7 +227,7 @@
         output += "\n";
         output += "export var ParserRules: NearleyRule[] = " + serializeRules(parser.rules, generate.typescript.builtinPostprocessors) + ";\n";
         output += "\n";
-        output += "export var ParserStart: string = " + JSON.stringify(parser.start) + ";\n";
+        output += "export var ParserStart: string = " + toCommentedShortName((parser.start)) + ";\n";
         return output;
     };
     generate.typescript.builtinPostprocessors = {


### PR DESCRIPTION
👋 Thanks for a great parser! I switched to it after using [ohm-js](https://www.npmjs.com/package/ohm-js)

Here is [my grammar](https://github.com/philschatz/puzzlescript-cli/blob/3aff641e62a8e818838e3af1376160d3be201b5b/src/parser/grammar.ne) (part of a project to [make puzzle games more embeddable and accessible](https://github.com/philschatz/puzzlescript-cli) to vision-impaired people).

As a result, the minified code drops from 772k to 200k. I tried using numbers directly but that caused parsing problems which I did not debug.

If this suggestion looks promising, I can try updating the tests and make any changes to the Pull Request.