### PR TITLE
Added support for flow library definitions

### DIFF
--- a/nearley.js.flow
+++ b/nearley.js.flow
@@ -1,0 +1,65 @@
+declare module "nearley" {
+
+    declare type Token = {
+        value: string
+    }
+
+    declare type Position = {
+        line: number,
+        col: number
+    }
+
+    declare type Symbol = {
+        literal?: Object,
+        type?: string,
+        toString(): string
+    }
+
+    declare function PostProcessor(data: Array<string>, reference: number, fail: Object): any
+
+    declare export class Rule {
+        constructor(name: string, symbols: Array<Symbol>, postprocess: Array<typeof PostProcessor>): Rule;
+        toString(withCursorAt: ?number): string;
+    }
+
+    declare class State {
+        constructor(rule: Rule, dot: number, reference: number, wantedBy: Array<State>): State;
+        toString(): string;
+        nextState(child: State): State;
+        build(): Array<string>;
+        finish(): void;
+    }
+
+    declare class Column {
+        constructor(grammar: Grammar, index: number): Column;
+        process(nextColumn: Column): void;
+        predict(exp: string): void;
+        complete(left: State, right: State): void;
+    }
+
+    declare export class Grammar {
+        constructor(rules: Array<Rule>, start:string): Grammar;
+        static fromCompiled(rules: Array<Rule>, start:string): Grammar;
+    }
+
+    declare class StreamLexer {
+        constructor(): StreamLexer;
+        reset(data: string, state: Position): void;
+        next(): Token|void;
+        save(): Position;
+        formatError(token: any, message: string): string;
+    }
+
+    declare export class Parser {
+        constructor(rules: Grammar|Array<Rule>, start: string, options: Object): Parser;
+        feed(chunk: string): Parser;
+        save(): Column;
+        restore(column: Column): void;
+        /**
+         * @deprecated rewind
+         */
+        rewind(index: number): void;
+        rewind(index: number): void;
+        finish(): Array<any>;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "files": [
     "bin/",
     "lib/",
-    "builtin/"
+    "builtin/",
+    "nearley.js.flow"
   ],
   "bin": {
     "nearleyc": "bin/nearleyc.js",


### PR DESCRIPTION
### Changes
Added flow library definitions for nearley.js
- Adds type inference  support for most major IDEs
- No changes to the codebase needed -> no harm done

### Test
```> nearley@2.15.1 test /home/tsubklewe/git/nearley
> mocha test/*.test.js



  bootstrapped lexer
    ✓ lexes directives
    ✓ lexes a simple rule
    ✓ lexes arrows
    ✓ lexes js code
    ✓ lexes charclasses
    ✓ rejects newline in charclass
    ✓ lexes macros
    ✓ lexes strings
    ✓ lexes strings non-greedily 
    ✓ lexes a rule

  bootstrapped parser
    ✓ parses directives
    ✓ parses simple rules
    ✓ parses postprocessors
    ✓ parses js code
    ✓ parses options
    ✓ parses tokens
    ✓ parses strings
    ✓ parses charclasses
    ✓ parses macro definitions
    ✓ parses macro use
    ✓ parses macro use
    ✓ parses a rule

  Linter
    ✓ runs without warnings on empty rules
    ✓ warns about undefined symbol
    ✓ doesn't warn about defined symbol
    ✓ doesn't warn about duplicate symbol

  bin/nearleyc
    ✓ builds for ES5 (77ms)
    ✓ builds for ES6+ (831ms)
    ✓ builds for CoffeeScript (183ms)
    ✓ builds for TypeScript (1322ms)
    ✓ builds modules in folders (87ms)
    ✓ builds modules with multiple includes of the same file (75ms)
    ✓ warns about undefined symbol (92ms)
    ✓ doesn't warn when used with the --quiet option (81ms)
    ✓ allows trailing comments without newline terminators (81ms)

  nearleyc: example grammars
    ✓ calculator example
    ✓ csscolor example
    ✓ exponential whitespace bug
    ✓ percent bug
    ✓ json
    ✓ classic crontab
    ✓ case-insensitive strings
    ✓ scannerless nearley grammar

  nearleyc: builtins
    ✓ generate includes id
    - nuller

  nearleyc: macros
    ✓ seems to work
    ✓ must be defined before use
    ✓ compiles a simple macro from external file

  Parser: API
    ✓ shows line number in errors
    ✓ shows token index in errors
    ✓ can save state
    ✓ can rewind
    ✓ won't rewind without `keepHistory` option
    ✓ restores line numbers
    ✓ restores column number

  Parser: examples
    ✓ nullable whitespace bug
    ✓ parentheses
    ✓ tokens
    ✓ json
    ✓ tosh (259ms)


  59 passing (3s)
  1 pending


Process finished with exit code 0
```
### Benchmark
```> nearley@2.15.1 benchmark /home/tsubklewe/git/nearley
> benchr test/benchmark.js

• test/benchmark.js:

  • calculator: parse.

    ✔  nearley  11,778.95  ops/sec  ±2.69%  (83 runs)

  • json: parse sample1k.

    ✔  nearley  88.97  ops/sec  ±8.07%  (65 runs)

  • tosh: parse.

    ✔  nearley  1,811.38  ops/sec  ±4.53%  (82 runs)


Process finished with exit code 0
```