### PR TITLE
Add tooling links to parcel-plugin-nearley and jest-transform-nearley

### DIFF
--- a/docs/md/tooling.md
+++ b/docs/md/tooling.md
@@ -111,3 +111,11 @@ compile grammars with a gulpfile.
 
 **Node** users can quickly create the framework for a large nearley-based
 project using [nearley-template](https://github.com/appology/nearley-template).
+
+**Parcel** users can use
+[parcel-plugin-nearley](https://github.com/adam1658/parcel-plugin-nearley) by
+Adam Rich to load grammars directly.
+
+**Jest** users can use
+[jest-transform-nearley](https://github.com/adam1658/jest-transform-nearley) by
+Adam Rich to load grammars directly.

--- a/docs/tooling.html
+++ b/docs/tooling.html
@@ -355,6 +355,12 @@ load grammars directly.</p>
 compile grammars with a gulpfile.</p>
 <p><strong>Node</strong> users can quickly create the framework for a large nearley-based
 project using <a href="https://github.com/appology/nearley-template">nearley-template</a>.</p>
+<p><strong>Parcel</strong> users can use
+<a href="https://github.com/adam1658/parcel-plugin-nearley">parcel-plugin-nearley</a> by
+Adam Rich to load grammars directly.</p>
+<p><strong>Jest</strong> users can use
+<a href="https://github.com/adam1658/jest-transform-nearley">jest-transform-nearley</a> by
+Adam Rich to load grammars directly.</p>
 
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a


### PR DESCRIPTION
I've written a parcel plugin and a jest transform for nearley grammars, both inspired by `nearley-loader`
I've added links to those on the tooling page.