### PR TITLE
PoC for reporting JS syntax errors in postprocessers

### DIFF
--- a/examples/js-error.ne
+++ b/examples/js-error.ne
@@ -1,0 +1,3 @@
+number -> [0-9]:+ {%
+        data -> data
+    %}

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -87,6 +87,11 @@
             if(rule.postprocess.builtin) {
                 rule.postprocess = builtinPostprocessors[rule.postprocess.builtin];
             }
+            try {
+                eval(`(function() { ${rule.postprocess} })`);
+            } catch (e) {
+                throw new Error(`Syntax error for postprocessor for rule '${rule.name}': ${e.message}`);
+            }
             ret += ', "postprocess": ' + tabulateString(dedentFunc(rule.postprocess), '        ', {indentFirst: false});
         }
         ret += '}';


### PR DESCRIPTION
This is only a PoC to gather suggestions. It attempts to implement https://github.com/kach/nearley/issues/440

What it doesn't do which I'd like for it to do is report the line number of the error. I believe nearley doesn't currently track line numbers though? I believe that functionality is deferred to the tokenizer. Please correct me if I am wrong about that.