### PR TITLE
Remove ES6+ code in lib

### DIFF
--- a/lib/nearley-language-bootstrapped.js
+++ b/lib/nearley-language-bootstrapped.js
@@ -1,4 +1,4 @@
-// Generated automatically by nearley, version 2.16.0
+// Generated automatically by nearley, version 2.17.0
 // http://github.com/Hardmath123/nearley
 (function () {
 function id(x) { return x[0]; }
@@ -9,7 +9,7 @@ function getValue(d) {
 
 function literals(list) {
     var rules = {}
-    for (let lit of list) {
+    for (var lit of list) {
         rules[lit] = {match: lit, next: 'main'}
     }
     return rules

--- a/lib/nearley-language-bootstrapped.ne
+++ b/lib/nearley-language-bootstrapped.ne
@@ -6,7 +6,7 @@ function getValue(d) {
 
 function literals(list) {
     var rules = {}
-    for (let lit of list) {
+    for (var lit of list) {
         rules[lit] = {match: lit, next: 'main'}
     }
     return rules

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -337,12 +337,12 @@
 
     Parser.prototype.reportError = function(token) {
         var lines = [];
-        const tokenDisplay = (token.type ? token.type + " token: " : "") + JSON.stringify(token.value !== undefined ? token.value : token);
+        var tokenDisplay = (token.type ? token.type + " token: " : "") + JSON.stringify(token.value !== undefined ? token.value : token);
         lines.push(this.lexer.formatError(token, "Syntax error"));
         lines.push('Unexpected ' + tokenDisplay + '. Instead, I was expecting to see one of the following:\n');
-        const lastColumnIndex = this.table.length - 2;
-        const lastColumn = this.table[lastColumnIndex];
-        const expectantStates = lastColumn.states
+        var lastColumnIndex = this.table.length - 2;
+        var lastColumn = this.table[lastColumnIndex];
+        var expectantStates = lastColumn.states
             .filter(function(state) {
                 const nextSymbol = state.rule.symbols[state.dot];
                 return nextSymbol && typeof nextSymbol !== "string";
@@ -351,16 +351,16 @@
         // Display a "state stack" for each expectant state
         // - which shows you how this state came to be, step by step. 
         // If there is more than one derivation, we only display the first one.
-        const stateStacks = expectantStates
+        var stateStacks = expectantStates
             .map(function(state) {
                 const stacks = this.buildStateStacks(state, []);
                 return stacks[0];
             }, this);
         // Display each state that is expecting a terminal symbol next.
         stateStacks.forEach(function(stateStack) {
-            const state = stateStack[0];
-            const nextSymbol = state.rule.symbols[state.dot];
-            const symbolDisplay = this.getSymbolDisplay(nextSymbol);
+            var state = stateStack[0];
+            var nextSymbol = state.rule.symbols[state.dot];
+            var symbolDisplay = this.getSymbolDisplay(nextSymbol);
             lines.push('A ' + symbolDisplay + ' based on:');
             this.displayStateStack(stateStack, lines);
         }, this);
@@ -372,9 +372,9 @@
     Parser.prototype.displayStateStack = function(stateStack, lines) {
         var lastDisplay;
         var sameDisplayCount = 0;
-        for (let j = 0; j < stateStack.length; j++) {
-            const state = stateStack[j];
-            const display = state.rule.toString(state.dot);
+        for (var j = 0; j < stateStack.length; j++) {
+            var state = stateStack[j];
+            var display = state.rule.toString(state.dot);
             if (display === lastDisplay) {
                 sameDisplayCount++;
             } else {
@@ -389,7 +389,7 @@
     };
 
     Parser.prototype.getSymbolDisplay = function(symbol) {
-        const type = typeof symbol;
+        var type = typeof symbol;
         if (type === "string") {
             return symbol;
         } else if (type === "object" && symbol.literal) {

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -7,7 +7,9 @@ const fs = require('fs');
 const expect = require('expect');
 
 const nearley = require('../lib/nearley');
-const {compile, parse} = require('./_shared');
+const shared =  require('./_shared');
+const compile = shared.compile;
+const parse = shared.parse;
 
 function read(filename) {
     return fs.readFileSync(filename, 'utf-8');


### PR DESCRIPTION
Fixes #457.

### Benchmark
#### Before:
```
$ npm run benchmark

> nearley@2.17.0 benchmark /home/hzhang/Code/nearley
> benchr test/benchmark.js

• test/benchmark.js:

  • calculator: parse.

    ✔  nearley  12,077.18  ops/sec  ±2.77%  (82 runs)

  • json: parse sample1k.

    ✔  nearley  111.83  ops/sec  ±0.89%  (72 runs)

  • tosh: parse.

    ✔  nearley  2,070.69  ops/sec  ±1.14%  (91 runs)
```
#### After:
```
$ npm run benchmark

> nearley@2.17.0 benchmark /home/hzhang/Code/nearley
> benchr test/benchmark.js

• test/benchmark.js:

  • calculator: parse.

    ✔  nearley  13,366.74  ops/sec  ±0.42%  (95 runs)

  • json: parse sample1k.

    ✔  nearley  112.56  ops/sec  ±0.88%  (78 runs)

  • tosh: parse.

    ✔  nearley  2,088.54  ops/sec  ±1.94%  (87 runs)
```

### Test:
```
$ npm run test

> nearley@2.17.0 test /home/hzhang/Code/nearley
> mocha test/*.test.js



  bootstrapped lexer
    ✓ lexes directives
    ✓ lexes a simple rule
    ✓ lexes arrows
    ✓ lexes js code
    ✓ lexes charclasses
    ✓ rejects newline in charclass
    ✓ lexes macros
    ✓ lexes strings
    ✓ lexes strings non-greedily 
    ✓ lexes a rule

  bootstrapped parser
    ✓ parses directives
    ✓ parses simple rules
    ✓ parses postprocessors
    ✓ parses js code
    ✓ parses options
    ✓ parses tokens
    ✓ parses strings
    ✓ parses charclasses
    ✓ parses macro definitions
    ✓ parses macro use
    ✓ parses macro use
    ✓ parses a rule

  Linter
    ✓ runs without warnings on empty rules
    ✓ warns about undefined symbol
    ✓ doesn't warn about defined symbol
    ✓ doesn't warn about duplicate symbol

  bin/nearleyc
    ✓ builds for ES5 (50ms)
    ✓ builds for ES6+ (448ms)
    ✓ builds for CoffeeScript (124ms)
    ✓ builds for TypeScript (1360ms)
    ✓ builds modules in folders (54ms)
    ✓ builds modules with multiple includes of the same file (58ms)
    ✓ warns about undefined symbol (57ms)
    ✓ doesn't warn when used with the --quiet option (57ms)
    ✓ allows trailing comments without newline terminators (54ms)

  nearleyc: example grammars
    ✓ calculator example
    ✓ csscolor example
    ✓ exponential whitespace bug
    ✓ percent bug
    ✓ json
    ✓ classic crontab
    ✓ case-insensitive strings
    ✓ scannerless nearley grammar

  nearleyc: builtins
    ✓ generate includes id
    - nuller

  nearleyc: macros
    ✓ seems to work
    ✓ must be defined before use
    ✓ compiles a simple macro from external file

  Parser: API
    ✓ shows line number in errors
    ✓ shows token index in errors
    ✓ shows user friend error with state stack info
    ✓ collapes identical consecutive lines
    ✓ does not infinitely recurse on self-referential states
    ✓ can save state
    ✓ can rewind
    ✓ won't rewind without `keepHistory` option
    ✓ restores line numbers
    ✓ restores column number

  Parser: examples
    ✓ nullable whitespace bug
    ✓ parentheses
    ✓ tokens
    ✓ json
    ✓ tosh (156ms)


  62 passing (3s)
  1 pending
```

I still need to create a minimal repro script so I can run this in Node v4 and test it catches everything