### PR TITLE
Remove nuller from documentation

### DIFF
--- a/docs/grammar.html
+++ b/docs/grammar.html
@@ -393,12 +393,10 @@ necessary. You can usually use a tokenizer instead.</p>
 </blockquote>
 </li>
 </ul>
-<p>nearley provides two built-in postprocessors for the most common scenarios:</p>
+<p>nearley provides one built-in postprocessor:</p>
 <ul>
 <li><code>id</code> returns the first element of the <code>data</code> array. This is useful to
 extract the content of a single-element array: <code>foo -&gt; bar {% id %}</code></li>
-<li><code>nuller</code> returns the JavaScript <code>null</code> value. This is useful for whitespace
-rules: <code>space -&gt; &quot; &quot; {% nuller %}</code></li>
 </ul>
 <h3 id="more-syntax-tips-and-tricks">More syntax: tips and tricks</h3>
 <h4 id="comments">Comments</h4>

--- a/docs/md/grammar.md
+++ b/docs/md/grammar.md
@@ -138,13 +138,10 @@ reject)`. Here,
   > slower to parse. So, we encourage you not to use `reject` unless absolutely
   > necessary. You can usually use a tokenizer instead.
 
-nearley provides two built-in postprocessors for the most common scenarios:
+nearley provides one built-in postprocessor:
 
 - `id` returns the first element of the `data` array. This is useful to
   extract the content of a single-element array: `foo -> bar {% id %}`
-- `nuller` returns the JavaScript `null` value. This is useful for whitespace
-  rules: `space -> " " {% nuller %}`
-
 
 ### More syntax: tips and tricks
 


### PR DESCRIPTION
As discussed in #97, there are a few postprocessors that are used internally (`joiner`, `arrconcat`, `arrpush`, and `nuller`) but are not accessible from within nearley grammar.

`nuller` was referenced in documentation despite being inaccessible.  This removes that reference so that documentation reflects reality.

Resolves #97