### PR TITLE
Fix importing compiled grammar from web worker

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -126,7 +126,7 @@
             + "&& typeof module.exports !== 'undefined') {\n";
         output += "   module.exports = grammar;\n";
         output += "} else {\n";
-        output += "   window." + exportName + " = grammar;\n";
+        output += "   self." + exportName + " = grammar;\n";
         output += "}\n";
         output += "})();\n";
         return output;
@@ -172,7 +172,7 @@
             + "&& typeof module.exports != 'undefined'\n";
         output += "    module.exports = grammar;\n";
         output += "  else\n";
-        output += "    window." + exportName + " = grammar;\n";
+        output += "    self." + exportName + " = grammar;\n";
         return output;
     };
 


### PR DESCRIPTION
Hi,
There was a problem when trying to import a generated grammar using `importScript` inside a web worker.
By declaring the grammar inside the `self` scope instead of `window` this should fix the issue without having any unintended effect for other use cases.