### PR TITLE
using-in-frontend.md doc fix: add `argv: []`

### DIFF
--- a/docs/md/using-in-frontend.md
+++ b/docs/md/using-in-frontend.md
@@ -27,7 +27,7 @@ function compileGrammar(sourceCode) {
     const grammarAst = grammarParser.results[0]; // TODO check for errors
 
     // Compile the AST into a set of rules
-    const grammarInfoObject = compile(grammarAst, {});
+    const grammarInfoObject = compile(grammarAst, { argv: [] });
     // Generate JavaScript code from the rules
     const grammarJs = generate(grammarInfoObject, "grammar");
 


### PR DESCRIPTION
this was necessary to get compilation with nearley 2.19.1 to work
-- at least when run in node.

Without it here's what I get:

```txt
./node_modules/nearley/lib/compile.js:37
                        opts.args[0] ? require('path').dirname(opts.args[0]) : process.cwd(),
                                 ^
TypeError: Cannot read property '0' of undefined
```