### PR TITLE
Unused Parameters in whitespace builtin

### DIFF
--- a/builtin/whitespace.ne
+++ b/builtin/whitespace.ne
@@ -1,5 +1,5 @@
 # Whitespace: `_` is optional, `__` is mandatory.
-_  -> wschar:* {% function(d) {return null;} %}
-__ -> wschar:+ {% function(d) {return null;} %}
+_  -> wschar:* {% function() {return null;} %}
+__ -> wschar:+ {% function() {return null;} %}
 
 wschar -> [ \t\n\v\f] {% id %}


### PR DESCRIPTION
fixes #499 

I'm not sure if there's any other places a javascript function like `function(d) {return null;}` occurs, but this is a good start.

I also cannot install the packages on my windows machine, so making the docs will be useless.

Any help?