### PR TITLE
Fixed states not being garbage collected with keep history set to false

### DIFF
--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -49,6 +49,9 @@
         state.right = child;
         if (state.isComplete) {
             state.data = state.build();
+            // Having right set here will prevent the right state and its children
+            // form being garbage collected
+            state.right = undefined;
         }
         return state;
     };


### PR DESCRIPTION
When keep history is set to false, States should be evacuated from memory after they are no longer needed. However, all completed states are assigned as a right child from other completed states even after their data is extracted, causing a reference chain that prevents them from ever being garbage collected.

See this screen shot of a memory dump after parsing a file with 34K lines:
![mem_dump](https://user-images.githubusercontent.com/699750/78527631-27139680-77e6-11ea-99c0-5b2cac3d62e9.jpg)

As you can see, parsing the said file caused a memory increase of ~350Mb, which was only garbage collected when the parser object  went out of scope.

With the suggested fix, the memory increase when parsing the same file was 60Mb. 

Attaching tests and benchmark output in a separate comment as suggested by the contribution guide.