### PR TITLE
Add option to auto-unwrap rule results

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -68,7 +68,13 @@
                 };
             } else if (productionRule.config) {
                 // This isn't a rule, it's an @config.
-                result.config[productionRule.config] = productionRule.value
+
+                // Convert autoUnwrap config to boolean
+                var value = productionRule.config === 'autoUnwrap'
+                    ? productionRule.value === 'true'
+                    : productionRule.value;
+
+                result.config[productionRule.config] = value;
             } else {
                 produceRules(productionRule.name, productionRule.rules, {});
                 if (!result.start) {
@@ -97,10 +103,20 @@
                     tokens.push(token);
                 }
             }
+
+            var postprocess = rule.postprocess;
+            var shouldAutoUnwrap = Object.prototype.hasOwnProperty.call(rule, 'autoUnwrap')
+                ? rule.autoUnwrap
+                : result.config.autoUnwrap;
+
+            if (shouldAutoUnwrap && tokens.length === 1) {
+                postprocess = 'id._auto(' + (postprocess || '') + ')';
+            }
+
             return new nearley.Rule(
                 ruleName,
                 tokens,
-                rule.postprocess
+                postprocess
             );
         }
 
@@ -169,7 +185,8 @@
                             literal: d
                         };
                     }),
-                    postprocess: {builtin: "joiner"}
+                    postprocess: {builtin: "joiner"},
+                    autoUnwrap: false,
                 }
             ], env);
             return newname;
@@ -210,6 +227,7 @@
             produceRules(name,
                 [{
                     tokens: [token.ebnf],
+                    autoUnwrap: false,
                 }, {
                     tokens: [name, token.ebnf],
                     postprocess: {builtin: "arrpush"}
@@ -261,7 +279,8 @@
             produceRules(name,
                 [{
                     tokens: [token.ebnf],
-                    postprocess: {builtin: "id"}
+                    postprocess: {builtin: "id"},
+                    autoUnwrap: false,
                 }, {
                     tokens: [],
                     postprocess: {builtin: "nuller"}

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -114,6 +114,7 @@
         output +=  "// http://github.com/Hardmath123/nearley\n";
         output += "(function () {\n";
         output += "function id(x) { return x[0]; }\n";
+        output += "id._auto = function(fn) { return fn ? function(d, l, r) { return fn(id(d), l, r); } : id; };";
         output += parser.body.join('\n');
         output += "var grammar = {\n";
         output += "    Lexer: " + parser.config.lexer + ",\n";


### PR DESCRIPTION
### Summary

This PR adds an option `@autoUnwrap`. If enabled, rules that consist of a single symbol will have their results unwrapped automatically (like adding `{% id %}` to them). 

### Motivation
```nearley
@autoUnwrap true

example	-> FOO ( BAR | BAZ )
FOO	-> "foo"i
BAR	-> "bar"i
BAZ	-> "baz"i
```

Before this PR, parsing the string `foobar` with the above grammar would yield the following result:
```js
[ [ 'foo' ], [ [ 'bar' ] ] ]
```

With this PR, the result will be
```js
[ 'foo', 'bar' ]
```

IMHO this makes postprocessing much more intuitive or completely alleviates the need for it in some places.

`@autoUnwrap true` also fixes #498. It generally improves macro usability and makes nested macros feasible:

```nearley
@autoUnwrap true

id[x]	-> $x
main	-> id[id["foobar"]]
```

The result of parsing `foobar` with above grammar is `"foobar"` while with `@autoUnwrap false` the result is `[[[[[ "foobar" ]]]]]` (that is a nesting depth of 5).

### Implementation

The implementation is pretty straight forward: during compilation, if `@autoUnwrap` is `true`, modify the `postprocessing` property of every rule that only has one token, such that the original postprocessing function will be called with `data[0]` instead of `data`. Thus, there is _no need for additional rule properties_ and there is _no runtime overhead_ compared to manually calling `id`.

In more detail, if an affected rule had the postprocess property `foo`, we will replace it with `id._auto(foo)` where

```js
id._auto = function(fn) {
  return fn
    ? function(d, l, r) {
        return fn(id(d), l, r);
      }
    : id;
};
```

I have decided to attach the function to `id` to avoid any naming collisions with custom preprocessors of existing grammars. The name also makes some sense since it's an automatic application of the `id` function.

### TODOs
I opened this PR as a draft since there are still a few things left to do. I will address those if this feature is wanted by the maintainers:

- Documentation
- Tests
- Support for all preprocessors (currently only supports JS)

---
I hope you think of this as a useful addition. I really liked writing a parser using nearley and this feature would resolve the only thing that bothered me when using it.