### PR TITLE
Bugfix: avoid error while reporting errors with recursive grammars

### DIFF
--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -356,7 +356,7 @@
         // If there is more than one derivation, we only display the first one.
         var stateStacks = expectantStates
             .map(function(state) {
-                return this.buildFirstStateStack(state, []);
+                return this.buildFirstStateStack(state, []) || [state];
             }, this);
         // Display each state that is expecting a terminal symbol next.
         stateStacks.forEach(function(stateStack) {


### PR DESCRIPTION
Currently, if you have recursive rules in your grammar, and you try to parse some input that has a syntax error, `reportError` crashes with `Cannot read property '0' of null`.

It is obviously tricky to report the full trace in this case, but it seems that at least reporting the state where the error occurred is reasonable.