### PR TITLE
Ignore typescript errors in generated file

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -188,7 +188,7 @@
         var output = "// Generated automatically by nearley, version " + parser.version + "\n";
         output +=  "// http://github.com/Hardmath123/nearley\n";
         output +=  "// Bypasses TS6133. Allow declared but unused functions.\n";
-        output +=  "// @ts-ignore\n";
+        output +=  "// @ts-nocheck\n";
         output += "function id(d: any[]): any { return d[0]; }\n";
         output += parser.customTokens.map(function (token) { return "declare var " + token + ": any;\n" }).join("")
         output += parser.body.join('\n');


### PR DESCRIPTION
The @ts-ignore flag only suppresses errors on the following line. @ts-nocheck should be used to ignore all errors in the file.