### PR TITLE
Link to moo-indentation-lexer module

### DIFF
--- a/docs/tokenizers.html
+++ b/docs/tokenizers.html
@@ -351,8 +351,7 @@ used to resolve <code>%</code>-specifiers in compiled nearley grammars.</li>
 </ul>
 <blockquote>
 <p>Note: if you are searching for a lexer that allows indentation-aware
-grammars (like in Python), you can still use moo. See <a href="https://gist.github.com/nathan/d8d1adea38a1ef3a6d6a06552da641aa">this
-example</a></p>
+grammars (like in Python), you can still use moo. See <a href="https://www.npmjs.com/package/moo-indentation-lexer">moo-indentation-lexer</a></p>
 </blockquote>
 <h3 id="custom-token-matchers">Custom token matchers</h3>
 <p>Aside from the lexer infrastructure, nearley provides a lightweight way to


### PR DESCRIPTION
I've created an NPM module for indentation-aware parsing, which I think would be more useful for linking than the current Gist.

Nb. the command `npm install && npm run make` failed to run on my computer, so the docs still need to be rebuilt.