### PR TITLE
Throw an error if grammer js file is not provided

### DIFF
--- a/bin/nearley-test.js
+++ b/bin/nearley-test.js
@@ -20,6 +20,9 @@ opts.version(version, '-v, --version')
 
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 
+if (!opts.args[0]) {
+    throw new Error('Please supply a grammer.js file path as a command-line argument');
+}
 var filename = require('path').resolve(opts.args[0]);
 var grammar = nearley.Grammar.fromCompiled(require(filename));
 if (opts.start) grammar.start = opts.start

--- a/bin/nearley-unparse.js
+++ b/bin/nearley-unparse.js
@@ -17,6 +17,9 @@ opts.version(version, '-v, --version')
 
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 
+if (!opts.args[0]) {
+    throw new Error('Please supply a grammer.js file path as a command-line argument');
+}
 var grammar = new require(require('path').resolve(opts.args[0]));
 
 // the main loop


### PR DESCRIPTION
Currently the error for missing arguments is obscure:

```
internal/validators.js:120
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at validateString (internal/validators.js:120:11)
    at Object.resolve (path.js:980:7)
    at Object.<anonymous> (/home/ali/projects/oblong/node_modules/nearley/bin/nearley-test.js:23:32)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
    at Module.load (internal/modules/cjs/loader.js:985:32)
    at Function.Module._load (internal/modules/cjs/loader.js:878:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'ERR_INVALID_ARG_TYPE'
}
error Command failed with exit code 1.
```

This change makes the resulting error a little more understandable.