### PR TITLE
Allow whitespace between macro brackets

### DIFF
--- a/lib/nearley-language-bootstrapped.js
+++ b/lib/nearley-language-bootstrapped.js
@@ -1,4 +1,4 @@
-// Generated automatically by nearley, version 2.17.0
+// Generated automatically by nearley, version 2.19.5
 // http://github.com/Hardmath123/nearley
 (function () {
 function id(x) { return x[0]; }
@@ -79,7 +79,7 @@ var grammar = {
     {"name": "prog", "symbols": ["prod"], "postprocess": function(d) { return [d[0]]; }},
     {"name": "prog", "symbols": ["prod", "ws", "prog"], "postprocess": function(d) { return [d[0]].concat(d[2]); }},
     {"name": "prod", "symbols": ["word", "_", (lexer.has("arrow") ? {type: "arrow"} : arrow), "_", "expression+"], "postprocess": function(d) { return {name: d[0], rules: d[4]}; }},
-    {"name": "prod", "symbols": ["word", {"literal":"["}, "wordlist", {"literal":"]"}, "_", (lexer.has("arrow") ? {type: "arrow"} : arrow), "_", "expression+"], "postprocess": function(d) {return {macro: d[0], args: d[2], exprs: d[7]}}},
+    {"name": "prod", "symbols": ["word", {"literal":"["}, "_", "wordlist", "_", {"literal":"]"}, "_", (lexer.has("arrow") ? {type: "arrow"} : arrow), "_", "expression+"], "postprocess": function(d) {return {macro: d[0], args: d[3], exprs: d[9]}}},
     {"name": "prod", "symbols": [{"literal":"@"}, "_", "js"], "postprocess": function(d) { return {body: d[2]}; }},
     {"name": "prod", "symbols": [{"literal":"@"}, "word", "ws", "word"], "postprocess": function(d) { return {config: d[1], value: d[3]}; }},
     {"name": "prod", "symbols": [{"literal":"@include"}, "_", "string"], "postprocess": function(d) {return {include: d[2].literal, builtin: false}}},
@@ -94,7 +94,7 @@ var grammar = {
     {"name": "completeexpression", "symbols": ["expr", "_", "js"], "postprocess": function(d) { return {tokens: d[0], postprocess: d[2]}; }},
     {"name": "expr_member", "symbols": ["word"], "postprocess": id},
     {"name": "expr_member", "symbols": [{"literal":"$"}, "word"], "postprocess": function(d) {return {mixin: d[1]}}},
-    {"name": "expr_member", "symbols": ["word", {"literal":"["}, "expressionlist", {"literal":"]"}], "postprocess": function(d) {return {macrocall: d[0], args: d[2]}}},
+    {"name": "expr_member", "symbols": ["word", {"literal":"["}, "_", "expressionlist", "_", {"literal":"]"}], "postprocess": function(d) {return {macrocall: d[0], args: d[3]}}},
     {"name": "expr_member$ebnf$1", "symbols": [{"literal":"i"}], "postprocess": id},
     {"name": "expr_member$ebnf$1", "symbols": [], "postprocess": function(d) {return null;}},
     {"name": "expr_member", "symbols": ["string", "expr_member$ebnf$1"], "postprocess": function(d) { if (d[1]) {return insensitive(d[0]); } else {return d[0]; } }},

--- a/lib/nearley-language-bootstrapped.ne
+++ b/lib/nearley-language-bootstrapped.ne
@@ -76,7 +76,7 @@ prog -> prod  {% function(d) { return [d[0]]; } %}
       | prod ws prog  {% function(d) { return [d[0]].concat(d[2]); } %}
 
 prod -> word _ %arrow _ expression+  {% function(d) { return {name: d[0], rules: d[4]}; } %}
-      | word "[" wordlist "]" _ %arrow _ expression+ {% function(d) {return {macro: d[0], args: d[2], exprs: d[7]}} %}
+      | word "[" _ wordlist _ "]" _ %arrow _ expression+ {% function(d) {return {macro: d[0], args: d[3], exprs: d[9]}} %}
       | "@" _ js  {% function(d) { return {body: d[2]}; } %}
       | "@" word ws word  {% function(d) { return {config: d[1], value: d[3]}; } %}
       | "@include"  _ string {% function(d) {return {include: d[2].literal, builtin: false}} %}
@@ -97,7 +97,7 @@ completeexpression -> expr  {% function(d) { return {tokens: d[0]}; } %}
 expr_member ->
       word {% id %}
     | "$" word {% function(d) {return {mixin: d[1]}} %}
-    | word "[" expressionlist "]" {% function(d) {return {macrocall: d[0], args: d[2]}} %} 
+    | word "[" _ expressionlist _ "]" {% function(d) {return {macrocall: d[0], args: d[3]}} %}
     | string "i":? {% function(d) { if (d[1]) {return insensitive(d[0]); } else {return d[0]; } } %}
     | "%" word {% function(d) {return {token: d[1]}} %}
     | charclass {% id %}


### PR DESCRIPTION
This change would allow whitespace to be used between square brackets for macros, for example:

```
macro1[ expression ] -> expression
macro1[ expression {% id %} ]
```