### PR TITLE
Add counting lineBreaks in js and btstring

### DIFF
--- a/lib/nearley-language-bootstrapped.js
+++ b/lib/nearley-language-bootstrapped.js
@@ -23,6 +23,7 @@ var rules = Object.assign({
     js: {
         match: /\{\%(?:[^%]|\%[^}])*\%\}/,
         value: x => x.slice(2, -2),
+        lineBreaks: true,
     },
     word: {match: /[\w\?\+]+/, next: 'afterWord'},
     string: {
@@ -34,6 +35,7 @@ var rules = Object.assign({
         match: /`[^`]*`/,
         value: x => x.slice(1, -1),
         next: 'main',
+        lineBreaks: true,
     },
 }, literals([
     ",", "|", "$", "%", "(", ")",

--- a/lib/nearley-language-bootstrapped.ne
+++ b/lib/nearley-language-bootstrapped.ne
@@ -20,6 +20,7 @@ var rules = Object.assign({
     js: {
         match: /\{\%(?:[^%]|\%[^}])*\%\}/,
         value: x => x.slice(2, -2),
+        lineBreaks: true,
     },
     word: {match: /[\w\?\+]+/, next: 'afterWord'},
     string: {
@@ -31,6 +32,7 @@ var rules = Object.assign({
         match: /`[^`]*`/,
         value: x => x.slice(1, -1),
         next: 'main',
+        lineBreaks: true,
     },
 }, literals([
     ",", "|", "$", "%", "(", ")",

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -240,4 +240,27 @@ describe('Parser: examples', () => {
             ].join("\n"))).toThrow(/Unexpected comment token/)
     })
 
+    it('should give accurate line and col counts in error reporting', () => {
+        var nearley = compile(read("lib/nearley-language-bootstrapped.ne"));
+        expect(() =>
+            parse(nearley, [
+                "",
+                "",
+                "@{%",
+                "",
+                "%}",
+                "",
+                "rule1 -> `",
+                "",
+                "",
+                "`",
+                "rule2 -> abc",
+                "  {%",
+                "  ([first]) =>",
+                "    first",
+                "  %}    ]",
+                ""
+            ].join("\n"))).toThrow(/line 15 col 9/)
+    })
+
 })


### PR DESCRIPTION
`moo` requires `lineBreaks` to be `true` for it to count the number of newlines within a token (presumably to save performance for the majority of the lexing within lines).

This change improves the accuracy of error messages for Nearley grammars - see https://github.com/kach/nearley/issues/539