### PR TITLE
allows old import style + allows nearely-test to run for typescript g…

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -226,7 +226,7 @@
         output += "  ParserStart: " + JSON.stringify(parser.start) + ",\n";
         output += "};\n";
         output += "\n";
-        output += "export default grammar;\n";
+        output += "export = grammar;\n";
 
         return output;
     };

--- a/test/nearleyc.test.js
+++ b/test/nearleyc.test.js
@@ -65,7 +65,7 @@ describe("bin/nearleyc", function() {
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         sh(`tsc ${outPath}.ts`);
-        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`).default);
+        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
         expect(parse(grammar, "<123>")).toEqual([ [ '<', '123', '>' ] ]);
     });
 


### PR DESCRIPTION
Fix the export default syntax for typescript to line up with js grammars.

This allows the old style 

`import * as grammar from './grammar';

export const parser = new Parser(Grammar.fromCompiled(grammar));`

as well as allowing nearley-test to actually test the compiled javascript.
