### PR TITLE
Allows javascript keywords as literals

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -131,7 +131,7 @@
                     if (result.customTokens.indexOf(name) === -1) {
                         result.customTokens.push(name);
                     }
-                    var expr = result.config.lexer + ".has(" + JSON.stringify(name) + ") ? {type: " + JSON.stringify(name) + "} : " + name;
+                    var expr = result.config.lexer + ".has(" + JSON.stringify(name) + ") ? {type: " + JSON.stringify(name) + "} : \"" + name + "\"";
                     return {token: "(" + expr + ")"};
                 }
                 return token;

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -131,7 +131,7 @@
                     if (result.customTokens.indexOf(name) === -1) {
                         result.customTokens.push(name);
                     }
-                    var expr = result.config.lexer + ".has(" + JSON.stringify(name) + ") ? {type: " + JSON.stringify(name) + "} : \"" + name + "\"";
+                    var expr = result.config.lexer + ".has(" + JSON.stringify(name) + ") ? {type: " + JSON.stringify(name) + "} : " + JSON.stringify(name);
                     return {token: "(" + expr + ")"};
                 }
                 return token;

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -190,7 +190,6 @@
         output +=  "// Bypasses TS6133. Allow declared but unused functions.\n";
         output +=  "// @ts-ignore\n";
         output += "function id(d: any[]): any { return d[0]; }\n";
-        output += parser.customTokens.map(function (token) { return "declare var " + token + ": any;\n" }).join("")
         output += parser.body.join('\n');
         output += "\n";
         output += "interface NearleyToken {\n";
@@ -212,7 +211,7 @@
         output += "  postprocess?: (d: any[], loc?: number, reject?: {}) => any;\n";
         output += "};\n";
         output += "\n";
-        output += "type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean };\n";
+        output += "type NearleySymbol = string | { type: any } | { test: (token: any) => boolean };\n";
         output += "\n";
         output += "interface Grammar {\n";
         output += "  Lexer: NearleyLexer | undefined;\n";

--- a/test/grammars/js-keywords.ne
+++ b/test/grammars/js-keywords.ne
@@ -1,0 +1,14 @@
+@{%
+const moo = require('moo')
+
+const lexer = moo.compile({
+  if: 'if',
+  function: 'function',
+  return: 'return'
+});
+const toText = (parts) => (parts.map(t => t.text));
+%}
+
+@lexer lexer
+
+expression -> %if %function %return {% toText %}

--- a/test/nearleyc.test.js
+++ b/test/nearleyc.test.js
@@ -110,6 +110,14 @@ describe("bin/nearleyc", function() {
         expect(stderr).toBe("");
     });
 
+    it("allows javascript keywords as literals", function () {
+        const {outPath, stdout, stderr} = externalNearleyc("grammars/js-keywords.ne", '.js');
+        expect(stderr).toBe("");
+        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
+        expect(parse(grammar, "iffunctionreturn")).toEqual([ [ 'if', 'function', 'return' ] ]);
+
+    });
+
 
 })
 


### PR DESCRIPTION
Looking at the generated typescript type for the tokens I guessed the real intent, so please correct me if I guessed wrong. In my understanding there were missing quotes when building tokens for the parser rules. Fixing this caused the typescript tests to fail, because the (incorrectly) used variables where given `any` type, thus making the ternary expression adopt this broader type and passing the test. Then I fixed the type to what I think it should be.

fixes #525 