### PR TITLE
TypeScript type definitions

### DIFF
--- a/lib/nearley.d.ts
+++ b/lib/nearley.d.ts
@@ -1,0 +1,120 @@
+// Type definitions for runtime classes
+//  - Parser (and ParserOptions)
+//  - Lexer (and Token, LexerState)
+//  - Grammar (and Rule, ParserRule, CompiledRules)
+//
+// Based on https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/nearley
+//
+// Definitions by: Nikita Litvin <https://github.com/deltaidea>
+//                 BendingBender <https://github.com/BendingBender>
+
+export as namespace nearley;
+
+export class Parser {
+    /**
+     * Reserved token for indicating a parse fail.
+     */
+    static readonly fail: {};
+
+    grammar: Grammar;
+    options: ParserOptions;
+    lexer: Lexer;
+    lexerState?: LexerState;
+    current: number;
+    /**
+     * An array of possible parsings. Each element is the thing returned by your grammar.
+     *
+     * Note that this is undefined before the first feed() call.
+     * It isn't typed as `any[] | undefined` to spare you the null checks when it's
+     * definitely an array.
+     */
+    results: any[];
+
+    constructor(grammar: Grammar, options?: ParserOptions);
+    constructor(rules: CompiledRules, start: string, options?: ParserOptions);
+
+    /**
+     * The Parser object can be fed data in parts with .feed(data).
+     * You can then find an array of parsings with the .results property.
+     * If results is empty, then there are no parsings.
+     * If results contains multiple values, then that combination is ambiguous.
+     *
+     * @throws If there are no possible parsings, nearley will throw an error
+     * whose `offset` property is the index of the offending token.
+     */
+    feed(chunk: string): this;
+    finish(): any[];
+    restore(column: {[key: string]: any, lexerState: LexerState}): void;
+    save(): {[key: string]: any, lexerState: LexerState};
+}
+
+export interface ParserOptions {
+    keepHistory?: boolean;
+    lexer?: Lexer;
+}
+
+export class Rule {
+    static highestId: number;
+
+    id: number;
+    name: string;
+    symbols: any[];
+    postprocess?: Postprocessor;
+
+    constructor(name: string, symbols: any[], postprocess?: Postprocessor);
+
+    toString(withCursorAt?: number): string;
+}
+
+export class Grammar {
+    static fromCompiled(rules: CompiledRules): Grammar;
+
+    rules: Rule[];
+    start: string;
+    byName: {[ruleName: string]: Rule[]};
+    lexer?: Lexer;
+
+    constructor(rules: Rule[]);
+}
+
+export interface CompiledRules {
+    Lexer?: Lexer;
+    ParserStart: string;
+    ParserRules: ParserRule[];
+}
+
+export interface ParserRule {
+    name: string;
+    symbols: any[];
+    postprocess?: Postprocessor;
+}
+
+export type Postprocessor = (data: any[], reference?: number, wantedBy?: {}) => void;
+
+export interface Lexer {
+    /**
+     * Sets the internal buffer to data, and restores line/col/state info taken from save().
+     */
+    reset(data: string, state?: LexerState): void;
+    /**
+     * Returns e.g. {type, value, line, col, …}. Only the value attribute is required.
+     */
+    next(): Token | undefined;
+    /**
+     * Returns an object describing the current line/col etc. This allows us
+     * to preserve this information between feed() calls, and also to support Parser#rewind().
+     * The exact structure is lexer-specific; nearley doesn't care what's in it.
+     */
+    save(): LexerState;
+    /**
+     * Returns a string with an error message describing the line/col of the offending token.
+     * You might like to include a preview of the line in question.
+     */
+    formatError(token: Token, message: string): string;
+}
+
+export type Token = string | { value: string; };
+
+export interface LexerState {
+    [x: string]: any;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.20.1",
   "description": "Simple, fast, powerful parser toolkit for JavaScript.",
   "main": "lib/nearley.js",
+  "types": "lib/nearley.d.ts",
   "dependencies": {
     "commander": "^2.19.0",
     "moo": "^0.5.0",
@@ -37,24 +38,24 @@
     "profile": "bin/nearleyc.js test/grammars/parens.ne > test/grammars/parens.js && node test/profile.js"
   },
   "author": "Hardmath123",
-  "contributors": "https://github.com/Hardmath123/nearley/graphs/contributors",
+  "contributors": "https://github.com/kach/nearley/graphs/contributors",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hardmath123/nearley.git"
+    "url": "https://github.com/kach/nearley.git"
   },
   "devDependencies": {
-    "@types/moo": "^0.3.0",
-    "@types/node": "^7.0.27",
+    "@types/moo": "^0.5.4",
+    "@types/node": "^14.14.41",
     "babel-cli": "^6.18.0",
     "babel-preset-env": "^1.6.0",
     "benchr": "^3.2.0",
     "coffee-script": "^1.10.0",
     "doctoc": "^1.3.0",
     "expect": "^1.20.2",
-    "microtime": "^2.1.2",
+    "microtime": "^3.0.0",
     "mocha": "^8.2.1",
-    "typescript": "^2.6.1"
+    "typescript": "^4.2.4"
   },
   "funding": {
     "type": "individual",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}


### PR DESCRIPTION
(still working on this branch, just letting you know)

I imported the definitions from DefinitelyTyped and added the missing constructor.
I am working on porting their tests to use `tsd`, theirs use `dtslint` which is a huge overkill.