### PR TITLE
use template strings for generated code

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -5,6 +5,11 @@
         root.generate = factory(root.nearley);
     }
 }(this, function(nearley) {
+    function generateComment(parser, beginning) {
+        var message = "Generated automatically by nearley, version"
+        var link = "http://github.com/Hardmath123/nearley"
+        return `${beginning} ${message} ${parser.version}\n${beginning} ${link}`
+    }
 
     function serializeRules(rules, builtinPostprocessors, extraIndent) {
         if (extraIndent == null) {
@@ -120,8 +125,7 @@
     };
 
     generate.js = generate._default = generate.javascript = function (parser, exportName) {
-        var output = `// Generated automatically by nearley, version ${parser.version}
-        // http://github.com/Hardmath123/nearley
+        var output = `${generateComment(parser, "//")}
         (function () {
         function id(x) { return x[0]; }
         ${parser.body.join('\n')}var grammar = {
@@ -149,8 +153,7 @@
     }
 
     generate.module = generate.esmodule = function (parser, exportName) {
-        var output = `// Generated automatically by nearley, version ${parser.version}
-        // http://github.com/Hardmath123/nearley
+        var output = `${generateComment(parser, "//")}
         function id(x) { return x[0]; }
         ${parser.body.join('\n')}let Lexer = ${parser.config.lexer};
         let ParserRules = ${serializeRules(parser.rules, generate.javascript.builtinPostprocessors)};
@@ -161,8 +164,7 @@
     };
 
     generate.cs = generate.coffee = generate.coffeescript = function (parser, exportName) {
-        var output = `# Generated automatically by nearley, version ${parser.version}
-        # http://github.com/Hardmath123/nearley
+        var output = `${generateComment(parser, "#")}
         do ->
           id = (d) -> d[0]
         ${tabulateString(dedentFunc(parser.body.join('\n')), '  ')}
@@ -194,8 +196,7 @@
     };
 
     generate.ts = generate.typescript = function (parser, exportName) {
-        var output = `// Generated automatically by nearley, version ${parser.version}
-        // http://github.com/Hardmath123/nearley
+        var output = `${generateComment(parser, "//")}
         // Bypasses TS6133. Allow declared but unused functions.
         // @ts-ignore
         function id(d: any[]): any { return d[0]; }

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -181,7 +181,8 @@
           if typeof module != 'undefined' && typeof module.exports != 'undefined'
             module.exports = grammar;
           else
-            window.${exportName} = grammar;`;
+            window.${exportName} = grammar;
+        `;
 
         return dedentMultiline(output, "        ");
     };
@@ -200,9 +201,8 @@
         // Bypasses TS6133. Allow declared but unused functions.
         // @ts-ignore
         function id(d: any[]): any { return d[0]; }
-        ${parser.customTokens.map(function (token) { return "declare var " + token + ": any;\n" }).join("")}
-        ${parser.body.join('\n')};
-
+        ${parser.customTokens.map(function (token) { return "declare var " + token + ": any;" }).join("\n")}
+        ${parser.body.join('\n')}
         interface NearleyToken {
           value: any;
           [key: string]: any;
@@ -236,7 +236,8 @@
           ParserStart: ${JSON.stringify(parser.start)},
         };
 
-        export default grammar;`;
+        export default grammar;
+        `;
 
         return dedentMultiline(output, "        ");
     };

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -16,6 +16,19 @@
         }).join(',\n    ') + '\n' + extraIndent + ']';
     }
 
+    function dedent(line, indent) {
+        if (line.slice(0, indent.length) === indent) {
+            return line.slice(indent.length);
+        }
+        return line;
+    }
+
+    function dedentMultiline(multiline, indent) {
+        return multiline.split("\n").map(function (line) {
+            return dedent(line, indent);
+        }).join("\n");
+    }
+
     function dedentFunc(func) {
         var lines = func.toString().split(/\n/);
 
@@ -39,11 +52,8 @@
             return lines;
         }
 
-        return lines.map(function dedent(line) {
-            if (line.slice(0, indent.length) === indent) {
-                return line.slice(indent.length);
-            }
-            return line;
+        return lines.map(function (line) {
+            return dedent(line, indent);
         });
     }
 
@@ -185,50 +195,50 @@
     };
 
     generate.ts = generate.typescript = function (parser, exportName) {
-        var output = "// Generated automatically by nearley, version " + parser.version + "\n";
-        output +=  "// http://github.com/Hardmath123/nearley\n";
-        output +=  "// Bypasses TS6133. Allow declared but unused functions.\n";
-        output +=  "// @ts-ignore\n";
-        output += "function id(d: any[]): any { return d[0]; }\n";
-        output += parser.customTokens.map(function (token) { return "declare var " + token + ": any;\n" }).join("")
-        output += parser.body.join('\n');
-        output += "\n";
-        output += "interface NearleyToken {\n";
-        output += "  value: any;\n";
-        output += "  [key: string]: any;\n";
-        output += "};\n";
-        output += "\n";
-        output += "interface NearleyLexer {\n";
-        output += "  reset: (chunk: string, info: any) => void;\n";
-        output += "  next: () => NearleyToken | undefined;\n";
-        output += "  save: () => any;\n";
-        output += "  formatError: (token: never) => string;\n";
-        output += "  has: (tokenType: string) => boolean;\n";
-        output += "};\n";
-        output += "\n";
-        output += "interface NearleyRule {\n";
-        output += "  name: string;\n";
-        output += "  symbols: NearleySymbol[];\n";
-        output += "  postprocess?: (d: any[], loc?: number, reject?: {}) => any;\n";
-        output += "};\n";
-        output += "\n";
-        output += "type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean };\n";
-        output += "\n";
-        output += "interface Grammar {\n";
-        output += "  Lexer: NearleyLexer | undefined;\n";
-        output += "  ParserRules: NearleyRule[];\n";
-        output += "  ParserStart: string;\n";
-        output += "};\n";
-        output += "\n";
-        output += "const grammar: Grammar = {\n";
-        output += "  Lexer: " + parser.config.lexer + ",\n";
-        output += "  ParserRules: " + serializeRules(parser.rules, generate.typescript.builtinPostprocessors, "  ") + ",\n";
-        output += "  ParserStart: " + JSON.stringify(parser.start) + ",\n";
-        output += "};\n";
-        output += "\n";
-        output += "export default grammar;\n";
+        var output = `// Generated automatically by nearley, version ${parser.version}
+        // http://github.com/Hardmath123/nearley
+        // Bypasses TS6133. Allow declared but unused functions.
+        // @ts-ignore
+        function id(d: any[]): any { return d[0]; }
+        ${parser.customTokens.map(function (token) { return "declare var " + token + ": any;\n" }).join("")}
+        ${parser.body.join('\n')};
 
-        return output;
+        interface NearleyToken {
+          value: any;
+          [key: string]: any;
+        };
+
+        interface NearleyLexer {
+          reset: (chunk: string, info: any) => void;
+          next: () => NearleyToken | undefined;
+          save: () => any;
+          formatError: (token: never) => string;
+          has: (tokenType: string) => boolean;
+        };
+
+        interface NearleyRule {
+          name: string;
+          symbols: NearleySymbol[];
+          postprocess?: (d: any[], loc?: number, reject?: {}) => any;
+        };
+
+        type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean };
+
+        interface Grammar {
+          Lexer: NearleyLexer | undefined;
+          ParserRules: NearleyRule[];
+          ParserStart: string;
+        };
+
+        const grammar: Grammar = {
+          Lexer: ${parser.config.lexer},
+          ParserRules: ${serializeRules(parser.rules, generate.typescript.builtinPostprocessors, "  ")},
+          ParserStart: ${JSON.stringify(parser.start)},
+        };
+
+        export default grammar;`;
+
+        return dedentMultiline(output, "        ");
     };
 
     generate.typescript.builtinPostprocessors = {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -163,27 +163,27 @@
     };
 
     generate.cs = generate.coffee = generate.coffeescript = function (parser, exportName) {
-        var output = "# Generated automatically by nearley, version " + parser.version + "\n";
-        output +=  "# http://github.com/Hardmath123/nearley\n";
-        output += "do ->\n";
-        output += "  id = (d) -> d[0]\n";
-        output += tabulateString(dedentFunc(parser.body.join('\n')), '  ') + '\n';
-        output += "  grammar = {\n";
-        output += "    Lexer: " + parser.config.lexer + ",\n";
-        output += "    ParserRules: " +
+        var output = `# Generated automatically by nearley, version ${parser.version}
+        # http://github.com/Hardmath123/nearley
+        do ->
+          id = (d) -> d[0]
+        ${tabulateString(dedentFunc(parser.body.join('\n')), '  ')}
+          grammar = {
+            Lexer: ${parser.config.lexer},
+            ParserRules: ${
             tabulateString(
                     serializeRules(parser.rules, generate.coffeescript.builtinPostprocessors),
-                    '      ',
+                    "      " + "        ",
                     {indentFirst: false})
-        + ",\n";
-        output += "    ParserStart: " + JSON.stringify(parser.start) + "\n";
-        output += "  }\n";
-        output += "  if typeof module != 'undefined' "
-            + "&& typeof module.exports != 'undefined'\n";
-        output += "    module.exports = grammar;\n";
-        output += "  else\n";
-        output += "    window." + exportName + " = grammar;\n";
-        return output;
+            },
+            ParserStart: ${JSON.stringify(parser.start)}
+          }
+          if typeof module != 'undefined' && typeof module.exports != 'undefined'
+            module.exports = grammar;
+          else
+            window.${exportName} = grammar;`;
+
+        return dedentMultiline(output, "        ");
     };
 
     generate.coffeescript.builtinPostprocessors = {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -149,15 +149,15 @@
     }
 
     generate.module = generate.esmodule = function (parser, exportName) {
-        var output = "// Generated automatically by nearley, version " + parser.version + "\n";
-        output +=  "// http://github.com/Hardmath123/nearley\n";
-        output += "function id(x) { return x[0]; }\n";
-        output += parser.body.join('\n');
-        output += "let Lexer = " + parser.config.lexer + ";\n";
-        output += "let ParserRules = " + serializeRules(parser.rules, generate.javascript.builtinPostprocessors) + ";\n";
-        output += "let ParserStart = " + JSON.stringify(parser.start) + ";\n";
-        output += "export default { Lexer, ParserRules, ParserStart };\n";
-        return output;
+        var output = `// Generated automatically by nearley, version ${parser.version}
+        // http://github.com/Hardmath123/nearley
+        function id(x) { return x[0]; }
+        ${parser.body.join('\n')}let Lexer = ${parser.config.lexer};
+        let ParserRules = ${serializeRules(parser.rules, generate.javascript.builtinPostprocessors)};
+        let ParserStart = ${JSON.stringify(parser.start)};
+        export default { Lexer, ParserRules, ParserStart };
+        `
+        return dedentMultiline(output, "        ");
     };
 
     generate.cs = generate.coffee = generate.coffeescript = function (parser, exportName) {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -120,26 +120,24 @@
     };
 
     generate.js = generate._default = generate.javascript = function (parser, exportName) {
-        var output = "// Generated automatically by nearley, version " + parser.version + "\n";
-        output +=  "// http://github.com/Hardmath123/nearley\n";
-        output += "(function () {\n";
-        output += "function id(x) { return x[0]; }\n";
-        output += parser.body.join('\n');
-        output += "var grammar = {\n";
-        output += "    Lexer: " + parser.config.lexer + ",\n";
-        output += "    ParserRules: " +
-            serializeRules(parser.rules, generate.javascript.builtinPostprocessors)
-            + "\n";
-        output += "  , ParserStart: " + JSON.stringify(parser.start) + "\n";
-        output += "}\n";
-        output += "if (typeof module !== 'undefined'"
-            + "&& typeof module.exports !== 'undefined') {\n";
-        output += "   module.exports = grammar;\n";
-        output += "} else {\n";
-        output += "   window." + exportName + " = grammar;\n";
-        output += "}\n";
-        output += "})();\n";
-        return output;
+        var output = `// Generated automatically by nearley, version ${parser.version}
+        // http://github.com/Hardmath123/nearley
+        (function () {
+        function id(x) { return x[0]; }
+        ${parser.body.join('\n')}var grammar = {
+            Lexer: ${parser.config.lexer},
+            ParserRules: ${serializeRules(parser.rules, generate.javascript.builtinPostprocessors)}
+          , ParserStart: ${JSON.stringify(parser.start)}
+        };
+        if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+           module.exports = grammar;
+        } else {
+           window.${exportName} = grammar;
+        }
+        })();
+        `
+
+        return dedentMultiline(output, "        ");
     };
 
     generate.javascript.builtinPostprocessors = {


### PR DESCRIPTION
I changed all the generated code to use template strings because I think it makes it a little bit easier to see what's going on and make changes. The generated code is the exact same for all the tests, except for javascript where I added a missing semicolon and missing whitespace between an identifier and an &&, not that it really matters. One thing to note is that I dedent the multiline template string at runtime just to I can keep it two tabs over without messing up the generated code, which I think is better than the alternative. I also extracted out the common text in all the generated comments.

I know it's really just a matter of style. It seems that you avoid es6 stuff, which is a fine reason to reject this PR. I wasn't sure if the exclusion of "newer" JS features is still a deliberate choice today.