### PR TITLE
Fix errors in docs

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -330,7 +330,7 @@ const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
 parser.feed(&quot;foo\n&quot;);
 
 // parser.results is an array of possible parsings.
-console.log(parser.results); // [[[[ &quot;foo&quot; ],&quot;\n&quot; ]]]</code></pre>
+console.log(JSON.stringify(parser.results)); // [[[[[&quot;foo&quot;],&quot;\n&quot;]]]]</code></pre>
 <h3 id="whats-next">What’s next?</h3>
 <p>Now that you have nearley installed, you can <a href="grammar">learn how to write a
 grammar</a>!</p>

--- a/docs/grammar.html
+++ b/docs/grammar.html
@@ -336,8 +336,9 @@ Postprocessors are wrapped in <code>{% %}</code>s:</p>
             rightOperand: data[2] // data[1] is &quot;+&quot;
         };
     }
-%}</code></pre>
-<p>The rule above will parse the string <code>5+10</code> into <code>{ operator: &quot;sum&quot;,
+%}
+number -&gt; [0-9]:+ {% d =&gt; parseInt(d[0].join(&quot;&quot;)) %}</code></pre>
+<p>The rules above will parse the string <code>5+10</code> into <code>{ operator: &quot;sum&quot;,
 leftOperand: 5, rightOperand: 10 }</code>.</p>
 <p>The postprocessor can be any function with signature <code>function(data, location,
 reject)</code>. Here,</p>
@@ -371,10 +372,11 @@ letters to match variables, except for the keyword <code>if</code>. In this case
 rule may be</p>
 <pre><code class="language-ne">variable -&gt; [a-z]:+ {%
     function(d,l, reject) {
-        if (d[0] == &#39;if&#39;) {
+        const name = d[0].join(&#39;&#39;);
+        if (name === &#39;if&#39;) {
             return reject;
         } else {
-            return {&#39;name&#39;: d[0]};
+            return { name };
         }
     }
 %}</code></pre>
@@ -429,7 +431,7 @@ main -&gt; sentence[&quot;Cows&quot;, (&quot;.&quot; | &quot;!&quot;)]</code></p
 <p>Macros are expanded at compile time and inserted in places they are used. They
 are not “real” rules. Therefore, macros <em>cannot</em> be recursive (<code>nearleyc</code> will
 go into an infinite loop trying to expand the macro-loop). They must also be
-defined <em>before</em> they are used.</p>
+defined <em>before</em> they are used (except by other macros).</p>
 <h3 id="additional-js">Additional JS</h3>
 <p>For more intricate postprocessors, or any other functionality you may need, you
 can include chunks of JavaScript code between production rules by surrounding

--- a/docs/md/getting-started.md
+++ b/docs/md/getting-started.md
@@ -80,7 +80,7 @@ const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
 parser.feed("foo\n");
 
 // parser.results is an array of possible parsings.
-console.log(parser.results); // [[[[ "foo" ],"\n" ]]]
+console.log(JSON.stringify(parser.results)); // [[[[["foo"],"\n"]]]]
 ```
 
 ### What's next?

--- a/docs/md/grammar.md
+++ b/docs/md/grammar.md
@@ -84,9 +84,10 @@ expression -> number "+" number {%
         };
     }
 %}
+number -> [0-9]:+ {% d => parseInt(d[0].join("")) %}
 ```
 
-The rule above will parse the string `5+10` into `{ operator: "sum",
+The rules above will parse the string `5+10` into `{ operator: "sum",
 leftOperand: 5, rightOperand: 10 }`.
 
 The postprocessor can be any function with signature `function(data, location,
@@ -125,10 +126,11 @@ reject)`. Here,
   ```ne
   variable -> [a-z]:+ {%
       function(d,l, reject) {
-          if (d[0] == 'if') {
+          const name = d[0].join('');
+          if (name === 'if') {
               return reject;
           } else {
-              return {'name': d[0]};
+              return { name };
           }
       }
   %}
@@ -216,7 +218,7 @@ main -> sentence["Cows", ("." | "!")]
 Macros are expanded at compile time and inserted in places they are used. They
 are not "real" rules. Therefore, macros *cannot* be recursive (`nearleyc` will
 go into an infinite loop trying to expand the macro-loop). They must also be
-defined *before* they are used.
+defined *before* they are used (except by other macros).
 
 ### Additional JS
 

--- a/docs/md/parser.md
+++ b/docs/md/parser.md
@@ -84,7 +84,7 @@ data.
 ```js
 try {
     parser.feed("Cow goes% moo.");
-} catch (err) {
+} catch (parseError) {
     console.log("Error at character " + parseError.offset); // "Error at character 9"
 }
 ```
@@ -92,10 +92,11 @@ try {
 Errors are nicely formatted for you:
 
 ```
-Error: invalid syntax at line 1 col 9:
+Error: Syntax error at line 1 col 9:
 
-  Cow goes% moo
+1 Cow goes% moo.
           ^
+
 Unexpected "%"
 ```
 
@@ -115,7 +116,7 @@ parser.feed("moo.");  // parser.results is ["yay!"]
 If you're done calling `feed()`, but the array is still empty, this indicates
 "unexpected end of input". Make sure to check there's at least one result.
 
-If there's more than one result, that indicates ambiguity--read on.
+If there's more than one result, that indicates ambiguity--see above.
 
 
 ### Accessing the parse table

--- a/docs/md/tokenizers.md
+++ b/docs/md/tokenizers.md
@@ -47,26 +47,28 @@ When using a lexer, there are two ways to match tokens:
 
 Here is an example of a simple grammar:
 
-```coffeescript
+```ne
 @{%
 const moo = require("moo");
 
 const lexer = moo.compile({
   ws:     /[ \t]+/,
   number: /[0-9]+/,
-  word: /[a-z]+/,
-  times:  /\*|x/
+  word: { match: /[a-z]+/, type: moo.keywords({ times: "x" }) },
+  times:  /\*/
 });
 %}
 
 # Pass your lexer object using the @lexer option:
 @lexer lexer
 
+expr -> multiplication {% id %} | trig {% id %}
+
 # Use %token to match any token of that type instead of "token":
 multiplication -> %number %ws %times %ws %number {% ([first, , , , second]) => first * second %}
 
 # Literal strings now match tokens with that text:
-trig -> "sin" %number
+trig -> "sin" %ws %number {% ([, , x]) => Math.sin(x) %}
 ```
 
 Have a look at [the Moo documentation](https://github.com/tjvr/moo#usage) to
@@ -121,5 +123,5 @@ const tokenNumber = { test: x => Number.isInteger(x) };
 
 main -> %tokenPrint %tokenNumber ";;"
 
-# parser.feed(["print", 12, ";;"]);
+# parser.feed(["print", 12, ";", ";"]);
 ```

--- a/docs/md/tooling.md
+++ b/docs/md/tooling.md
@@ -20,7 +20,7 @@ The Unparser takes a (compiled) parser and outputs a random string that would
 be accepted by the parser.
 
 ```bash
-$ nearley-unparse -s number <(nearleyc builtin/prims.ne)
+$ nearley-unparse -s jsonfloat <(nearleyc builtin/number.ne)
 -6.22E94
 ```
 

--- a/docs/parser.html
+++ b/docs/parser.html
@@ -323,14 +323,15 @@ of the offending token. There is no way to recover from this by feeding more
 data.</p>
 <pre><code class="language-js">try {
     parser.feed(&quot;Cow goes% moo.&quot;);
-} catch (err) {
+} catch (parseError) {
     console.log(&quot;Error at character &quot; + parseError.offset); // &quot;Error at character 9&quot;
 }</code></pre>
 <p>Errors are nicely formatted for you:</p>
-<pre><code>Error: invalid syntax at line 1 col 9:
+<pre><code>Error: Syntax error at line 1 col 9:
 
-  Cow goes% moo
+1 Cow goes% moo.
           ^
+
 Unexpected &quot;%&quot;</code></pre><p><strong>After <code>feed()</code> finishes</strong>, the <code>results</code> array will contain all possible
 parsings.</p>
 <p>If there are no possible parsings given the current input, but in the <em>future</em>
@@ -341,7 +342,7 @@ parser.feed(&quot;goes &quot;); // parser.results is []
 parser.feed(&quot;moo.&quot;);  // parser.results is [&quot;yay!&quot;]</code></pre>
 <p>If you’re done calling <code>feed()</code>, but the array is still empty, this indicates
 “unexpected end of input”. Make sure to check there’s at least one result.</p>
-<p>If there’s more than one result, that indicates ambiguity–read on.</p>
+<p>If there’s more than one result, that indicates ambiguity–see above.</p>
 <h3 id="accessing-the-parse-table">Accessing the parse table</h3>
 <p>If you are familiar with the Earley parsing algorithm, you can access the
 internal parse table using <code>Parser.table</code> (this, for example, is how

--- a/docs/tokenizers.html
+++ b/docs/tokenizers.html
@@ -307,25 +307,27 @@ super-fast lexer. Construct a lexer using <code>moo.compile</code>.</p>
 </li>
 </ul>
 <p>Here is an example of a simple grammar:</p>
-<pre><code class="language-coffeescript">@{%
+<pre><code class="language-ne">@{%
 const moo = require(&quot;moo&quot;);
 
 const lexer = moo.compile({
   ws:     /[ \t]+/,
   number: /[0-9]+/,
-  word: /[a-z]+/,
-  times:  /\*|x/
+  word: { match: /[a-z]+/, type: moo.keywords({ times: &quot;x&quot; }) },
+  times:  /\*/
 });
 %}
 
 # Pass your lexer object using the @lexer option:
 @lexer lexer
 
+expr -&gt; multiplication {% id %} | trig {% id %}
+
 # Use %token to match any token of that type instead of &quot;token&quot;:
 multiplication -&gt; %number %ws %times %ws %number {% ([first, , , , second]) =&gt; first * second %}
 
 # Literal strings now match tokens with that text:
-trig -&gt; &quot;sin&quot; %number</code></pre>
+trig -&gt; &quot;sin&quot; %ws %number {% ([, , x]) =&gt; Math.sin(x) %}</code></pre>
 <p>Have a look at <a href="https://github.com/tjvr/moo#usage">the Moo documentation</a> to
 learn more about writing a tokenizer.</p>
 <p>You use the parser as usual: call <code>parser.feed(data)</code>, and nearley will give
@@ -369,7 +371,7 @@ const tokenNumber = { test: x =&gt; Number.isInteger(x) };
 
 main -&gt; %tokenPrint %tokenNumber &quot;;;&quot;
 
-# parser.feed([&quot;print&quot;, 12, &quot;;;&quot;]);</code></pre>
+# parser.feed([&quot;print&quot;, 12, &quot;;&quot;, &quot;;&quot;]);</code></pre>
 
 
     <div id="footer"><p>nearley is MIT-licensed. It's maintained by <a

--- a/docs/tooling.html
+++ b/docs/tooling.html
@@ -288,7 +288,7 @@ to test a new parser.</p>
 <h3 id="nearley-unparse-the-unparser">nearley-unparse: The Unparser</h3>
 <p>The Unparser takes a (compiled) parser and outputs a random string that would
 be accepted by the parser.</p>
-<pre><code class="language-bash">$ nearley-unparse -s number &lt;(nearleyc builtin/prims.ne)
+<pre><code class="language-bash">$ nearley-unparse -s jsonfloat &lt;(nearleyc builtin/number.ne)
 -6.22E94</code></pre>
 <p>You can use the Unparser to…</p>
 <ul>


### PR DESCRIPTION
Thanks for making this library!

I found the docs very helpful to learn how to use nearley, but as I went through them, I came across a few discrepancies, which this PR corrects.

- `node --version` `v17.3.0`
- `nearleyc --version` `2.20.1`

Please let me know if any of these changes are ill-scoped, and I can remove them to help merge this PR.