### PR TITLE
Allow the user to pick an output language

### DIFF
--- a/bin/nearleyc.js
+++ b/bin/nearleyc.js
@@ -8,12 +8,15 @@ var StreamWrapper = require('../lib/stream.js');
 
 var version = require('../package.json').version;
 
+var validLangs = /(js|javascript|module|esmodule|cs|coffee|coffeescript|ts|typescript)/;
+
 opts.version(version, '-v, --version')
     .arguments('<file.ne>')
     .option('-o, --out [filename.js]', 'File to output to (defaults to stdout)', false)
     .option('-e, --export [name]', 'Variable to set parser to', 'grammar')
     .option('-q, --quiet', 'Suppress linter')
     .option('--nojs', 'Do not compile postprocessors')
+    .option('-l, --language [language]', 'Which output programming language to generate', validLangs, '_default')
     .parse(process.argv);
 
 
@@ -34,5 +37,5 @@ input
             Object.assign({version: version}, opts)
         );
         if (!opts.quiet) lint(c, {'out': process.stderr, 'version': version});
-        output.write(generate(c, opts.export));
+        output.write(generate[opts.language](c, opts.export));
     });


### PR DESCRIPTION
I would like to be able to use the cli to generate typescript output.  This change adds an optional language flag to specify which of the existing generators might be used.  