### PR TITLE
feat: add `--include-paths` support in nearleyc

### DIFF
--- a/bin/nearley-test.js
+++ b/bin/nearley-test.js
@@ -61,4 +61,3 @@ if (typeof(opts.input) === "undefined") {
     if (!opts.quiet) writeTable(output, parser);
     writeResults(output, parser);
 }
-

--- a/bin/nearleyc.js
+++ b/bin/nearleyc.js
@@ -12,6 +12,7 @@ opts.version(version, '-v, --version')
     .arguments('<file.ne>')
     .option('-o, --out [filename.js]', 'File to output to (defaults to stdout)', false)
     .option('-e, --export [name]', 'Variable to set parser to', 'grammar')
+    .option('--include-paths [includePaths]', 'Paths to lookup include files')
     .option('-q, --quiet', 'Suppress linter')
     .option('--nojs', 'Do not compile postprocessors')
     .parse(process.argv);

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -12,6 +12,17 @@
             opts.alreadycompiled = [];
         }
 
+        var nodePath = require('path');
+        var nodeFs = require('fs');
+        var includePaths = [];
+        if (opts.includePaths && opts.includePaths.split) {
+            includePaths = opts.includePaths.split(',').map(function(p) {
+                return nodePath.resolve(process.cwd(), p);
+            });
+        }
+        var firstIncludePath = (opts.args && opts.args[0]) ? nodePath.dirname(opts.args[0]) : process.cwd();
+        includePaths.push(firstIncludePath);
+
         var result = {
             rules: [],
             body: [], // @directives list
@@ -33,12 +44,15 @@
                 // Include file
                 var path;
                 if (!productionRule.builtin) {
-                    path = require('path').resolve(
-                        opts.args[0] ? require('path').dirname(opts.args[0]) : process.cwd(),
-                        productionRule.include
-                    );
+                    for (let i = 0; i < includePaths.length; i++) {
+                      var pathToLookup = nodePath.resolve(includePaths[i], productionRule.include);
+                      if (nodeFs.existsSync(pathToLookup)) {
+                        path = pathToLookup;
+                        break;
+                      }
+                    }
                 } else {
-                    path = require('path').resolve(
+                    path = nodePath.resolve(
                         __dirname,
                         '../builtin/',
                         productionRule.include

--- a/test/grammars/include-paths/include-example.ne
+++ b/test/grammars/include-paths/include-example.ne
@@ -1,0 +1,1 @@
+@include "multi-include/a.ne"

--- a/test/nearleyc.test.js
+++ b/test/nearleyc.test.js
@@ -1,6 +1,7 @@
 
 const fs = require('fs');
 const expect = require('expect');
+const path = require('path');
 
 const nearley = require('../lib/nearley');
 const {compile, evalGrammar, parse, nearleyc} = require('./_shared');
@@ -110,7 +111,11 @@ describe("bin/nearleyc", function() {
         expect(stderr).toBe("");
     });
 
-
+    it("accepets --include-paths", function () {
+        const includePath = path.join(__dirname, 'grammars');
+        const {stdout, stderr} = externalNearleyc("grammars/include-paths/include-example.ne", '.js', ['--include-paths', includePath]);
+        expect(stderr).toBe("");
+    });
 })
 
 describe('nearleyc: example grammars', function() {
@@ -219,6 +224,7 @@ describe('nearleyc: builtins', () => {
         const g = evalGrammar(source)
         expect(parse(g, " ")).toEqual([null])
     })
+
 })
 
 describe('nearleyc: macros', () => {


### PR DESCRIPTION
related #604 

example:

```nearley
@preprocessor typescript
@lexer lexer

@builtin "postprocessors.ne"

# from shared-grammars
@include "whitespace.ne"
@include "config.ne"
@include "comment.ne"
```

```text
shared-grammars
├── comment.ne
├── config.d.ts
├── config.ne
└── whitespace.ne
src
└── gantt
```

```
nearleyc src/gantt/parser/gantt.ne --include-paths ./shared-grammars  -o src/gantt/parser/gantt.ts
```