### PR TITLE
Remove illegal end tag and fix warnings

### DIFF
--- a/examples/calculator/index.html
+++ b/examples/calculator/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <title>Calculator!</title>
         <script src="../../lib/nearley.js"></script>
         <script src="grammar.js"></script>
-        <style type="text/css">
+        <style>
             html, body {
                 margin: 0; padding: 0;
                 font-size: 14pt;
@@ -55,7 +55,7 @@
     <body>
         <div id="main">
            <div class="vertically-centered">
-               <input  id="input" autofocus type="text" placeholder="3+4*ln(e+pi^2)"></input><br/>
+               <input  id="input" autofocus type="text" placeholder="3+4*ln(e+pi^2)"><br/>
                <span id="help">Enter an expression and hit &lt;enter&gt;.</span><br/>
                <span id="info">Made with <a href="http://github.com/Hardmath123/nearley">nearley</a>.</span>
            </div>


### PR DESCRIPTION
- Removed </input> as it's not a valid tag ("Error: Stray end tag input")
- Fixed "Warning: Consider adding a lang attribute to the html start tag to declare the language of this document."
- Fixed "Warning: The type attribute for the style element is not needed and should be omitted."