### PR TITLE
Uses the exportname correctly in generating the Typescript template.

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -220,13 +220,13 @@
         output += "  ParserStart: string;\n";
         output += "};\n";
         output += "\n";
-        output += "const grammar: Grammar = {\n";
+        output += "const " + exportName + ": Grammar = {\n";
         output += "  Lexer: " + parser.config.lexer + ",\n";
         output += "  ParserRules: " + serializeRules(parser.rules, generate.typescript.builtinPostprocessors, "  ") + ",\n";
         output += "  ParserStart: " + JSON.stringify(parser.start) + ",\n";
         output += "};\n";
         output += "\n";
-        output += "export default grammar;\n";
+        output += "export default " + exportName + ";\n";
 
         return output;
     };


### PR DESCRIPTION
When providing the name of the export using the `-e, --export [name]` option with nearleyc, the names in the generated typescript file do not reflect the value of this parameter.  This pull-request should fix that.