### PR TITLE
#632 Buffer chunks to avoid partial matches in nearleyc

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -10,8 +10,22 @@ function StreamWrapper(parser) {
 
 util.inherits(StreamWrapper, Writable);
 
+
+var tailPrevChunk='';
 StreamWrapper.prototype._write = function write(chunk, encoding, callback) {
-    this._parser.feed(chunk.toString());
+    //https://github.com/kach/nearley/issues/632
+    //Token might be span multiple chunks. 
+    var chunkString = chunk.toString();
+    var idxLastNewline = chunkString.lastIndexOf('\n');
+    if (idxLastNewline === -1 ){
+        tailPrevChunk += chunkString;
+        return;
+    }
+
+    var alteredChunk = tailPrevChunk + chunkString.substring(0,idxLastNewline);
+    tailPrevChunk= chunkString.substring(idxLastNewline);
+
+    this._parser.feed(alteredChunk);
     callback();
 };
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -6,27 +6,33 @@ var util = require('util');
 function StreamWrapper(parser) {
     Writable.call(this);
     this._parser = parser;
+    this._buffer='';
 }
 
 util.inherits(StreamWrapper, Writable);
 
 
-var tailPrevChunk='';
 StreamWrapper.prototype._write = function write(chunk, encoding, callback) {
     //https://github.com/kach/nearley/issues/632
     //Token might be span multiple chunks. 
     var chunkString = chunk.toString();
     var idxLastNewline = chunkString.lastIndexOf('\n');
-    if (idxLastNewline === -1 ){
-        tailPrevChunk += chunkString;
+    if (idxLastNewline === -1 ) {
+        this._buffer += chunkString;
         return;
     }
 
-    var alteredChunk = tailPrevChunk + chunkString.substring(0,idxLastNewline);
-    tailPrevChunk= chunkString.substring(idxLastNewline);
+    var alteredChunk = this._buffer + chunkString.substring(0,idxLastNewline);
+    this._buffer= chunkString.substring(idxLastNewline);
 
     this._parser.feed(alteredChunk);
     callback();
 };
+
+StreamWrapper.prototype._final = function final(callback) {
+    this._parser.feed(this._buffer);
+    this._buffer = '';
+    callback();
+}
 
 module.exports = StreamWrapper;

--- a/test/nearleyc.test.js
+++ b/test/nearleyc.test.js
@@ -110,6 +110,12 @@ describe("bin/nearleyc", function() {
         expect(stderr).toBe("");
     });
 
+    it('correctly handles long tokens that span multiple chunks', function() {
+        const {outPath, stdout, stderr} = externalNearleyc("grammars/long-tokens-split-over-multiple-chunks.ne", '.js');
+        expect(stderr).toBe("");
+        expect(stdout).toBe("");
+        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
+    });
 
 })
 


### PR DESCRIPTION
Issue : https://github.com/kach/nearley/issues/632

Cause :    The StreamWriter receives tokens in chunks and passes it to the parser which in turn immediately passes it to a lexer.    The default chunk size is 64KB.   Token for a production rule could span chunks leading the lexer to match a partial token based on on the incomplete chunk. 

Fix :  Production rules in the nearley grammar are new line `\n` delimited.   Passing only passing characters upto the newline should always result in a full match.    StreamWriter buffers any characters in the chunk past the last newline prepends it to the next chunk.     

Implements the `Writable._finish` to flush the buffer.  This addresses grammar files that may not have a newline at the end of the file. 